### PR TITLE
Update link to sponsored transaction tutorial

### DIFF
--- a/sponsoredTransactions/backend/CHANGELOG.md
+++ b/sponsoredTransactions/backend/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased changes
+
+## 1.0.0
+
+- Initial sponsored transaction back end

--- a/sponsoredTransactions/frontend/CHANGELOG.md
+++ b/sponsoredTransactions/frontend/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Unreleased changes
+
+## 1.1.0
+
+- Update link to sponsored transaction tutorial
+
+## 1.0.0
+
+- Initial sponsored transaction front end

--- a/sponsoredTransactions/frontend/package.json
+++ b/sponsoredTransactions/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sponsored-transactions",
     "packageManager": "yarn@3.2.0",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/sponsoredTransactions/frontend/src/SponsoredTransactions.tsx
+++ b/sponsoredTransactions/frontend/src/SponsoredTransactions.tsx
@@ -945,7 +945,7 @@ export default function SponsoredTransactions(props: WalletConnectionProps) {
                 Version: {version} |{' '}
                 <a
                     style={{ color: 'white' }}
-                    href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/"
+                    href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/sponsoredTransactions/index.html"
                     target="_blank"
                     rel="noreferrer"
                 >


### PR DESCRIPTION
## Purpose

When the sponsored transaction front end was initially written, the associated tutorial was not merged yet. Update the tutorial link at the front end to point to that sponsored transaction tutorial now.

## Changes

Update link to sponsored transaction tutorial
