### PR TITLE
Add link to source code in signMessage

### DIFF
--- a/signMessage/CHANGELOG.md
+++ b/signMessage/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.2.0
+
+-   Add link to source code
+
+## 0.1.0
+
+-   Initial signing frontend

--- a/signMessage/package.json
+++ b/signMessage/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "signMessage",
-  "version": "0.1.0",
+  "name": "sign_message",
+  "version": "0.2.0",
   "private": true,
   "dependencies": {
     "@concordium/browser-wallet-api-helpers": "^0.2.0",

--- a/signMessage/src/App.tsx
+++ b/signMessage/src/App.tsx
@@ -15,6 +15,7 @@ import SignClient from "@walletconnect/sign-client";
 import WalletConnect2, {signMessage, trySend} from "./WalletConnect2";
 import {SessionTypes} from "@walletconnect/types";
 import BrowserWallet, {trySendTransaction, sign, wrapPromise} from "./BrowserWallet";
+import Footer from "./Footer";
 
 const rpc = new JsonRpcClient(new HttpProvider(JSON_RPC_URL));
 
@@ -251,6 +252,7 @@ export default function App() {
                     <button onClick={handleSubmitSign}>Sign</button>
                 </Col>
             </Row>
+            <Footer />
         </Container>
     );
 }

--- a/signMessage/src/Footer.tsx
+++ b/signMessage/src/Footer.tsx
@@ -1,0 +1,22 @@
+import { Col } from 'react-bootstrap';
+import packageInfo from '../package.json';
+
+function Footer() {
+    return (
+        <>
+            <hr />
+            <Col style={{ textAlign: 'center' }}>
+                Version: {packageInfo.version} |{' '}
+                <a
+                    href="https://github.com/Concordium/concordium-dapp-examples/tree/main/signMessage"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    Source code.
+                </a>
+            </Col>
+        </>
+    );
+}
+
+export default Footer;


### PR DESCRIPTION
## Purpose

All hosted front ends should have a way to find the source code easily. Either through a link to an associated tutorial (that contains links to the source code) or if no tutorial exists through a link to the source code.

## Changes

- Add link to source code (signMessage).
- Add `ChangeLog`.
- Add `version` to front end.