### PR TITLE
Change sponsored transactions dApp to use grpc

### DIFF
--- a/sponsoredTransactions/frontend/CHANGELOG.md
+++ b/sponsoredTransactions/frontend/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.1.0
+
+- Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
+
 ## 2.0.0
 
 - Remove tab to register public key 

--- a/sponsoredTransactions/frontend/CHANGELOG.md
+++ b/sponsoredTransactions/frontend/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-## 2.1.0
+## 2.0.1
 
 - Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
 

--- a/sponsoredTransactions/frontend/package.json
+++ b/sponsoredTransactions/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sponsored-transactions",
     "packageManager": "yarn@3.2.0",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/sponsoredTransactions/frontend/package.json
+++ b/sponsoredTransactions/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sponsored-transactions",
     "packageManager": "yarn@3.2.0",
-    "version": "2.1.0",
+    "version": "2.0.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/sponsoredTransactions/frontend/src/SponsoredTransactions.tsx
+++ b/sponsoredTransactions/frontend/src/SponsoredTransactions.tsx
@@ -225,14 +225,12 @@ async function generateUpdateOperatorMessage(
     return serializedMessage;
 }
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 async function getPublicKey(rpcClient: ConcordiumGRPCClient, account: string) {
     const res = await rpcClient.getAccountInfo(new AccountAddress(account));
     const publicKey = res?.accountCredentials[0].value.contents.credentialPublicKeys.keys[0].verifyKey;
     return publicKey;
 }
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 async function getNonceOf(rpcClient: ConcordiumGRPCClient, account: string) {
     const param = serializeTypeValue(
         {

--- a/sponsoredTransactions/frontend/src/constants.ts
+++ b/sponsoredTransactions/frontend/src/constants.ts
@@ -1,12 +1,15 @@
-import { BrowserWalletConnector, ephemeralConnectorType, WalletConnectConnector } from '@concordium/react-components';
+import {
+    BrowserWalletConnector,
+    ephemeralConnectorType,
+    Network,
+    WalletConnectConnector,
+} from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
 import moment from 'moment';
 
 export const VERIFIER_URL = '/api';
 
 export const REFRESH_INTERVAL = moment.duration(5, 'seconds');
-
-export const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
 
 export const SPONSORED_TX_CONTRACT_NAME = 'cis3_nft';
 
@@ -35,6 +38,16 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
         url: '#',
         icons: ['https://walletconnect.com/walletconnect-logo.png'],
     },
+};
+
+export const STAGENET: Network = {
+    name: 'stagenet',
+    genesisHash: '38bf770b4c247f09e1b62982bb71000c516480c5a2c5214dadac6da4b1ad50e5',
+    grpcOpts: {
+        baseUrl: 'https://grpc.stagenet.concordium.com:20000',
+    },
+    jsonRpcUrl: 'https://json-rpc.stagenet.concordium.com/',
+    ccdScanBaseUrl: 'https://stagenet.ccdscan.io/',
 };
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);


### PR DESCRIPTION
## Purpose

addresses #19 

Migrate dApp to use gRPC

## Changes

- Replace jsonRPC with gRPC.
- Hardcode stagenet configuration temporarily until we can deploy the smart contract to testnet and migrate this dApp in a follow up PR.
