### PR TITLE
Change the sponsored transaction dApp to use the testnet smart contract

### DIFF
--- a/sponsoredTransactions/Dockerfile
+++ b/sponsoredTransactions/Dockerfile
@@ -1,5 +1,5 @@
 ARG node_base_image=node:16-slim
-ARG rust_base_image=rust:1.62
+ARG rust_base_image=rust:1.65
 
 FROM ${node_base_image} AS frontend
 
@@ -23,7 +23,7 @@ WORKDIR /build
 ENV PORT=8080
 ENV NODE=http://node.testnet.concordium.com:20000
 ENV LOG_LEVEL=info
-ENV SMART_CONTRACT_INDEX=4376
+ENV SMART_CONTRACT_INDEX=6372
 
 ENV ACCOUNT_KEY_FILE=/KEY_FILE
 

--- a/sponsoredTransactions/frontend/CHANGELOG.md
+++ b/sponsoredTransactions/frontend/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.0.2
+
+- Change the dApp to use the testnet smart contract index.
+
 ## 2.0.1
 
 - Migrate dApp from using deprecated JSON-RPC client to new gRPC client.

--- a/sponsoredTransactions/frontend/package.json
+++ b/sponsoredTransactions/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sponsored-transactions",
     "packageManager": "yarn@3.2.0",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"
@@ -55,7 +55,7 @@
     "scripts": {
         "lint": "eslint . --cache --max-warnings 0 --ext .ts,.tsx",
         "type:check": "yarn run tsc --noEmit",
-        "build": "SMART_CONTRACT_INDEX=0 node --loader ts-node/esm ./esbuild.config.ts; cp ./src/assets/* ./dist",
+        "build": "SMART_CONTRACT_INDEX=6372 node --loader ts-node/esm ./esbuild.config.ts; cp ./src/assets/* ./dist",
         "watch": "cross-env WATCH=1 yarn build",
         "start": "live-server ./dist"
     }

--- a/sponsoredTransactions/frontend/src/SponsoredTransactions.tsx
+++ b/sponsoredTransactions/frontend/src/SponsoredTransactions.tsx
@@ -16,12 +16,12 @@ import {
     useConnection,
     useConnect,
     typeSchemaFromBase64,
+    TESTNET,
 } from '@concordium/react-components';
 import { version } from '../package.json';
 
 import { submitUpdateOperator, submitTransfer, mint } from './utils';
 import {
-    STAGENET,
     SPONSORED_TX_CONTRACT_NAME,
     NONCE_OF_PARAMETER_SCHEMA,
     NONCE_OF_RETURN_VALUE_SCHEMA,
@@ -311,7 +311,7 @@ export default function SponsoredTransactions(props: WalletConnectionProps) {
 
     const { connection, setConnection, account, genesisHash } = useConnection(connectedAccounts, genesisHashes);
     const { connect, isConnecting, connectError } = useConnect(activeConnector, setConnection);
-    const grpcClient = useGrpcClient(STAGENET);
+    const grpcClient = useGrpcClient(TESTNET);
 
     const [publicKeyError, setPublicKeyError] = useState('');
     const [nextNonceError, setNextNonceError] = useState('');

--- a/sponsoredTransactions/frontend/src/constants.ts
+++ b/sponsoredTransactions/frontend/src/constants.ts
@@ -1,9 +1,4 @@
-import {
-    BrowserWalletConnector,
-    ephemeralConnectorType,
-    Network,
-    WalletConnectConnector,
-} from '@concordium/react-components';
+import { BrowserWalletConnector, ephemeralConnectorType, WalletConnectConnector } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
 import moment from 'moment';
 
@@ -38,16 +33,6 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
         url: '#',
         icons: ['https://walletconnect.com/walletconnect-logo.png'],
     },
-};
-
-export const STAGENET: Network = {
-    name: 'stagenet',
-    genesisHash: '38bf770b4c247f09e1b62982bb71000c516480c5a2c5214dadac6da4b1ad50e5',
-    grpcOpts: {
-        baseUrl: 'https://grpc.stagenet.concordium.com:20000',
-    },
-    jsonRpcUrl: 'https://json-rpc.stagenet.concordium.com/',
-    ccdScanBaseUrl: 'https://stagenet.ccdscan.io/',
 };
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);


### PR DESCRIPTION
## Purpose

Protocol 6 was not live on Testnet a few weeks ago, so the sponsored transaction dApp was run on Stagenet to test its functionalities. Now, protocol 6 is live on testnet. Switching back the dApp to Testnet.

Closes https://github.com/Concordium/concordium-dapp-examples/issues/19

## Changes

Change the sponsored transaction dApp to use the Testnet smart contract.
