### PR TITLE
Use metadata file with 0 decimals

### DIFF
--- a/sponsoredTransactionsAuction/README.md
+++ b/sponsoredTransactionsAuction/README.md
@@ -34,7 +34,7 @@ docker run -p 8080:8080 --mount type=bind,source="$(pwd)"/<ACCOUNT_KEY_FILE>,tar
 e.g.
 
 ```shell
-docker run -p 8080:8080 --mount type=bind,source="$(pwd)"/4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export,target=/KEY,readonly -e ACCOUNT_KEY_FILE=/KEY -e PORT=8080 -e NODE=http://node.testnet.concordium.com:20000 -e LOG_LEVEL=debug -e CIS2_TOKEN_CONTRACT_INDEX=7370 -e AUCTION_CONTRACT_INDEX=7415 sponsored_transactions
+docker run -p 8080:8080 --mount type=bind,source="$(pwd)"/4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export,target=/KEY,readonly -e ACCOUNT_KEY_FILE=/KEY -e PORT=8080 -e NODE=http://node.testnet.concordium.com:20000 -e LOG_LEVEL=debug -e CIS2_TOKEN_CONTRACT_INDEX=7723 -e AUCTION_CONTRACT_INDEX=7724 sponsored_transactions
 ```
 
 Note: To get your `ACCOUNT_KEY_FILE` (the `4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export` file), export it from the Concordium Browser Wallet for Web.

--- a/sponsoredTransactionsAuction/backend/README.md
+++ b/sponsoredTransactionsAuction/backend/README.md
@@ -18,13 +18,13 @@ All of the above is available by using `--help` to get usage information.
 
 An example to run the backend with basic settings and testnet node would be:
 ```shell
-cargo run -- --node http://node.testnet.concordium.com:20000 --account-key-file <YourAccountPathToYourKeys> --cis2-token-smart-contract-index 7370 --auction-smart-contract-index 7415 --log-level debug
+cargo run -- --node http://node.testnet.concordium.com:20000 --account-key-file <YourAccountPathToYourKeys> --cis2-token-smart-contract-index 7723 --auction-smart-contract-index 7724 --log-level debug
 ```
 
 An example to run the backend with some filled in example settings would be:
 
 ```shell
-cargo run -- --node http://node.testnet.concordium.com:20000 --account-key-file ./4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export --cis2-token-smart-contract-index 7370 --auction-smart-contract-index 7415 --log-level debug 
+cargo run -- --node http://node.testnet.concordium.com:20000 --account-key-file ./4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export --cis2-token-smart-contract-index 7723 --auction-smart-contract-index 7724 --log-level debug 
 ```
 
 To get your account file (the `4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export` file in the above example), export it from the Concordium Browser wallet for web.

--- a/sponsoredTransactionsAuction/backend/src/main.rs
+++ b/sponsoredTransactionsAuction/backend/src/main.rs
@@ -82,7 +82,7 @@ struct App {
     frontend_assets: std::path::PathBuf,
     #[clap(
         long = "cis2-token-smart-contract-index",
-        default_value = "7370",
+        default_value = "7723",
         env = "CIS2_TOKEN_CONTRACT_INDEX",
         help = "The cis2 token smart contract index which the sponsored transaction is submitted \
                 to."
@@ -90,7 +90,7 @@ struct App {
     cis2_token_smart_contract_index: u64,
     #[clap(
         long = "auction-smart-contract-index",
-        default_value = "7399",
+        default_value = "7724",
         env = "AUCTION_CONTRACT_INDEX",
         help = "The auction smart contract index which the sponsored transaction is submitted to."
     )]

--- a/sponsoredTransactionsAuction/frontend/package.json
+++ b/sponsoredTransactionsAuction/frontend/package.json
@@ -8,13 +8,13 @@
         "node": ">=18.0.0"
     },
     "scripts": {
-        "dev": "CIS2_TOKEN_CONTRACT_INDEX=7370 AUCTION_CONTRACT_INDEX=7415 vite",
-        "build": "tsc && CIS2_TOKEN_CONTRACT_INDEX=7370 AUCTION_CONTRACT_INDEX=7415 vite build",
+        "dev": "CIS2_TOKEN_CONTRACT_INDEX=7723 AUCTION_CONTRACT_INDEX=7724 vite",
+        "build": "tsc && CIS2_TOKEN_CONTRACT_INDEX=7723 AUCTION_CONTRACT_INDEX=7724 vite build",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
         "lint-fix": "yarn lint --fix",
         "generate-client": "tsx ./scripts/generate-client.ts",
         "fmt": "prettier -w .",
-        "preview": "CIS2_TOKEN_CONTRACT_INDEX=7370 AUCTION_CONTRACT_INDEX=7415 vite preview"
+        "preview": "CIS2_TOKEN_CONTRACT_INDEX=7723 AUCTION_CONTRACT_INDEX=7724 vite preview"
     },
     "dependencies": {
         "@concordium/react-components": "^0.4.0",

--- a/sponsoredTransactionsAuction/frontend/src/constants.ts
+++ b/sponsoredTransactionsAuction/frontend/src/constants.ts
@@ -26,7 +26,8 @@ export const EPSILON_ENERGY = 200n;
 export const AUCTION_START = '2000-01-01T12:00:00Z'; // Hardcoded value for simplicity for this demo dApp.
 export const AUCTION_END = '2050-01-01T12:00:00Z'; // Hardcoded value for simplicity for this demo dApp.
 
-export const METADATA_URL = 'https://s3.eu-central-1.amazonaws.com/tokens.testnet.concordium.com/ft/wccd'; // We use the same metadat URL for every token_id for simplicity for this demo dApp. In production, you should consider using a different metadata file for each token_id.
+export const METADATA_URL =
+    'https://gist.githubusercontent.com/DOBEN/e035ef44705cdf8919f72c98a25d54eb/raw/8c6b375a2dff448e7bbd12a27fc420d41f268f12/gistfile1.txt'; // We use the same metadat URL for every token_id for simplicity for this demo dApp. In production, you should consider using a different metadata file for each token_id.
 
 export const TRANSFER_SCHEMA =
     'EAEUAAUAAAAIAAAAdG9rZW5faWQdAAYAAABhbW91bnQbJQAAAAQAAABmcm9tFQIAAAAHAAAAQWNjb3VudAEBAAAACwgAAABDb250cmFjdAEBAAAADAIAAAB0bxUCAAAABwAAAEFjY291bnQBAQAAAAsIAAAAQ29udHJhY3QBAgAAAAwWAQQAAABkYXRhHQE=';


### PR DESCRIPTION
## Purpose

closes #37 

## Changes

- Change metadata file to use a token with decimals 0. Token amounts in the wallets will be displayed as integers (no micro tokens such as 0.000001) which makes it easier for this demo app.
- Redeployed contracts to use the above metadata file for all token ids created.