### PR TITLE
Simplify the flow in the changeStatus endpoint to be easier to understand

### DIFF
--- a/trackAndTrace/smart-contract/src/lib.rs
+++ b/trackAndTrace/smart-contract/src/lib.rs
@@ -265,7 +265,7 @@ impl<S: HasStateApi> State<S> {
         targets.insert(to)
     }
 
-    /// Get the items and the possible state transitions for that item in its
+    /// Get the item and the possible state transitions for that item in its
     /// current state.
     pub fn get_item_and_transitions(
         &mut self,


### PR DESCRIPTION
## Purpose

Make the entrypoint for changing the item simpler and avoid a disclaimer.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.