### PR TITLE
Improve logging gallery backend

### DIFF
--- a/gallery/verifier/Cargo.lock
+++ b/gallery/verifier/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "gallery-verifier"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/gallery/verifier/Cargo.toml
+++ b/gallery/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gallery-verifier"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2021"
 license-file = "../../LICENSE"

--- a/gallery/verifier/src/handlers.rs
+++ b/gallery/verifier/src/handlers.rs
@@ -108,6 +108,7 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl warp::Reply, Infall
     } else {
         let code = StatusCode::INTERNAL_SERVER_ERROR;
         let message = "Internal error.";
+        log::debug!("Internal error. Original error: {:?}", err);
         Ok(mk_reply(message.into(), code))
     }
 }

--- a/gallery/verifier/src/handlers.rs
+++ b/gallery/verifier/src/handlers.rs
@@ -108,7 +108,7 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl warp::Reply, Infall
     } else {
         let code = StatusCode::INTERNAL_SERVER_ERROR;
         let message = "Internal error.";
-        log::debug!("Internal error. Original error: {:?}", err);
+        log::error!("Internal error. Original error: {:#?}", err);
         Ok(mk_reply(message.into(), code))
     }
 }


### PR DESCRIPTION
## Purpose

We get in-frequent errors at the gallery backend where the current cause is not known. Improve logging at the gallery backend to facilitate the investigation.

```
2579 [2024-02-25T16:29:04Z INFO  warp::filters::trace] processing request
 2580 [2024-02-25T16:29:04Z ERROR warp::filters::trace] unable to process request (internal error) ssecondstatus=500 error=None
 2581 [2024-02-25T16:29:29Z INFO  warp::filters::trace] request; method=GET path=/ version=HTTP/1.1
```
## Changes

- Log internal error.
