### PR TITLE
Add nonceOf function

### DIFF
--- a/trackAndTrace/indexer/README.md
+++ b/trackAndTrace/indexer/README.md
@@ -49,7 +49,7 @@ This will produce a single binary `indexer` in `target/release` directory.
 ## Run the indexer
 
 ```console
-cargo run -- --node https://grpc.testnet.concordium.com:20000 --contract "<7835,0>" --log-level debug
+cargo run -- --node https://grpc.testnet.concordium.com:20000 --contract "<8144,0>" --log-level debug
 ```
 
 ## Configure the indexer
@@ -58,7 +58,7 @@ There are a few options to configure the indexer:
 
 - `--node` is the endpoint to the Concordium node grpc v2 API. If not specified, the default value `https://grpc.testnet.concordium.com:20000` is used.
 
-- `--contract` is the contract index of the track-and-trace smart contract, e.g. <7835,0>.
+- `--contract` is the contract index of the track-and-trace smart contract, e.g. <8144,0>.
 
 - `--db-connection` should specify your postgreSQL database connection. If not specified, the default value `host=localhost dbname=indexer user=postgres password=password port=5432` is used.
 

--- a/trackAndTrace/indexer/src/main.rs
+++ b/trackAndTrace/indexer/src/main.rs
@@ -17,6 +17,7 @@ use concordium_rust_sdk::{
 use std::collections::{BTreeMap, BTreeSet};
 use tokio_postgres::types::{Json, ToSql};
 use track_and_trace as contract;
+use track_and_trace::AdditionalData;
 mod db;
 use crate::db::*;
 
@@ -113,10 +114,11 @@ impl indexer::ProcessEvent for StoreEvents {
                 single_contract_update_info.0.execution_tree.events()
             {
                 for (event_index, event) in events.iter().enumerate() {
-                    let parsed_event: contract::Event = event.parse()?;
+                    let parsed_event: contract::Event<AdditionalData> = event.parse()?;
 
-                    if let contract::Event::ItemStatusChanged(item_status_change_event) =
-                        parsed_event
+                    if let contract::Event::<AdditionalData>::ItemStatusChanged(
+                        item_status_change_event,
+                    ) = parsed_event
                     {
                         let params: [&(dyn ToSql + Sync); 6] = [
                             &(block_info.block_slot_time),
@@ -149,7 +151,10 @@ impl indexer::ProcessEvent for StoreEvents {
                             single_contract_update_info.0.transaction_hash,
                             event_index
                         );
-                    } else if let contract::Event::ItemCreated(item_created_event) = parsed_event {
+                    } else if let contract::Event::<AdditionalData>::ItemCreated(
+                        item_created_event,
+                    ) = parsed_event
+                    {
                         let params: [&(dyn ToSql + Sync); 5] = [
                             &(block_info.block_slot_time),
                             &single_contract_update_info.0.transaction_hash.as_ref(),

--- a/trackAndTrace/smart-contract/src/lib.rs
+++ b/trackAndTrace/smart-contract/src/lib.rs
@@ -965,7 +965,7 @@ fn contract_serialization_helper(_ctx: &ReceiveContext, _host: &Host<State>) -> 
     Ok(())
 }
 
-/// The parameter type for the contract functions `noneOf`. A query
+/// The parameter type for the contract functions `nonceOf`. A query
 /// for the nonce of a given account.
 #[derive(Debug, Serialize, SchemaType)]
 #[concordium(transparent)]

--- a/trackAndTrace/smart-contract/src/lib.rs
+++ b/trackAndTrace/smart-contract/src/lib.rs
@@ -412,7 +412,7 @@ pub struct TransitionEdges {
 #[init(
     contract = "track_and_trace",
     parameter = "Vec<TransitionEdges>",
-    event = "Event",
+    event = "Event<AdditionalData>",
     enable_logger
 )]
 fn init(
@@ -587,7 +587,7 @@ pub struct ChangeItemStatusParams<A> {
 #[receive(
     contract = "track_and_trace",
     name = "changeItemStatus",
-    parameter = "ChangeItemStatusParams",
+    parameter = "ChangeItemStatusParams<AdditionalData>",
     error = "CustomContractError",
     mutable,
     enable_logger

--- a/trackAndTrace/test-scripts/src/main.rs
+++ b/trackAndTrace/test-scripts/src/main.rs
@@ -157,14 +157,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Update items from `Produced` to `InTransit`
     for i in 0..args.num_items {
-        let param: ChangeItemStatusParams = ChangeItemStatusParams {
+        let param: ChangeItemStatusParams<AdditionalData> = ChangeItemStatusParams {
             item_id:         i,
             new_status:      Status::InTransit,
             additional_data: AdditionalData::empty(),
         };
 
         let tx_dry_run = contract_client
-            .dry_run_update::<ChangeItemStatusParams, ViewError>(
+            .dry_run_update::<ChangeItemStatusParams<AdditionalData>, ViewError>(
                 "changeItemStatus",
                 Amount::zero(),
                 admin_key.address,
@@ -185,14 +185,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Update items from `InTransit` to `InStore`
     for i in 0..args.num_items {
-        let param: ChangeItemStatusParams = ChangeItemStatusParams {
+        let param: ChangeItemStatusParams<AdditionalData> = ChangeItemStatusParams {
             item_id:         i,
             new_status:      Status::InStore,
             additional_data: AdditionalData::empty(),
         };
 
         let tx_dry_run = contract_client
-            .dry_run_update::<ChangeItemStatusParams, ViewError>(
+            .dry_run_update::<ChangeItemStatusParams<AdditionalData>, ViewError>(
                 "changeItemStatus",
                 Amount::zero(),
                 admin_key.address,
@@ -214,14 +214,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Update items from `InStore` to `Sold`
     for i in 0..args.num_items {
-        let param: ChangeItemStatusParams = ChangeItemStatusParams {
+        let param: ChangeItemStatusParams<AdditionalData> = ChangeItemStatusParams {
             item_id:         i,
             new_status:      Status::Sold,
             additional_data: AdditionalData::empty(),
         };
 
         let tx_dry_run = contract_client
-            .dry_run_update::<ChangeItemStatusParams, ViewError>(
+            .dry_run_update::<ChangeItemStatusParams<AdditionalData>, ViewError>(
                 "changeItemStatus",
                 Amount::zero(),
                 admin_key.address,


### PR DESCRIPTION
## Purpose

We want to further generalize `AddtitionalData` so that we can derive a standard for block explorers to display it more meaningfully. Add generic type for the `AdditionalData`.

## Changes

- Add `nonceOf` view function for front end to get the current nonce.
- Use generic type for `AdditionalData`.