### PR TITLE
Add release github actions

### DIFF
--- a/.github/workflows/release-track-and-trace-dapp-docker.yml
+++ b/.github/workflows/release-track-and-trace-dapp-docker.yml
@@ -1,0 +1,58 @@
+# This job builds and publishes the docker image for the track and trace server to
+# the dockerhub image repository.
+name: Create and publish the docker image for the track and trace server.
+
+on:
+  workflow_dispatch: # allows manual trigger
+
+  push:
+    tags:
+      # The `server` uses the versioning convention: `frontend_version-backend_version`. 
+      - 'track-and-trace/*.*.*-*.*.*'   
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: track-and-trace-server
+  SPONSORED_TRANSACTION_BACKEND_BASE_URL: "https://trackntrace.testnet.concordium.com:8000"
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    environment: testnet-builds
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      # Uses the `docker/login-action` action to log in to the Container registry.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract version tag from package.json
+        id: meta
+        run: |
+          export FRONTEND_VERSION=$(jq -r .version trackAndTrace/frontend/package.json)
+          export BACKEND_VERSION=$(yq .package.version trackAndTrace/indexer/Cargo.toml)
+          export FULL_IMAGE_TAG="${{ env.REGISTRY }}/concordium/$IMAGE_NAME:$FRONTEND_VERSION-$BACKEND_VERSION"
+          echo "::notice FULL_IMAGE_TAG=${FULL_IMAGE_TAG}"
+          # Make sure the image does not exist. Abort if we can retrieve any metadata.
+          if docker manifest inspect ${FULL_IMAGE_TAG} > /dev/null; then
+             echo "::error ${FULL_IMAGE_TAG} already exists"
+             exit 1
+          else
+             # Store the full image tag into a tag variable for the following step.
+             echo "tag=${FULL_IMAGE_TAG}" > "$GITHUB_OUTPUT"
+          fi
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: ./dockerfiles/server.Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tag }}
+        build-args:
+          SPONSORED_TRANSACTION_BACKEND_BASE_URL: ${{ SPONSORED_TRANSACTION_BACKEND_BASE_URL }}

--- a/.github/workflows/release-track-and-trace-indexer-docker.yml
+++ b/.github/workflows/release-track-and-trace-indexer-docker.yml
@@ -7,7 +7,7 @@ on:
 
   push:
     tags:
-      - 'track-and-trace/*.*.*'   
+      - 'track-and-trace/indexer/*.*.*'   
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/release-track-and-trace-indexer-docker.yml
+++ b/.github/workflows/release-track-and-trace-indexer-docker.yml
@@ -1,24 +1,22 @@
-# This job builds and publishes the docker image for the track and trace server to
+# This job builds and publishes the docker image for the track and trace indexer to
 # the dockerhub image repository.
-name: Create and publish the docker image for the track and trace server.
+name: Create and publish the docker image for the track and trace indexer.
 
 on:
   workflow_dispatch: # allows manual trigger
 
   push:
     tags:
-      # The `server` uses the versioning convention: `frontend_version-backend_version`. 
-      - 'track-and-trace/*.*.*-*.*.*'   
+      - 'track-and-trace/*.*.*'   
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: track-and-trace-server
-  SPONSORED_TRANSACTION_BACKEND_BASE_URL: "https://trackntrace.testnet.concordium.com:8000"
+  IMAGE_NAME: dapp-track-and-trace-indexer
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    environment: testnet-builds
+    environment: track-and-trace
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,12 +29,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Extract version tag from package.json
+      - name: Extract version tag from Cargo.toml
         id: meta
         run: |
-          export FRONTEND_VERSION=$(jq -r .version trackAndTrace/frontend/package.json)
           export BACKEND_VERSION=$(yq .package.version trackAndTrace/indexer/Cargo.toml)
-          export FULL_IMAGE_TAG="${{ env.REGISTRY }}/concordium/$IMAGE_NAME:$FRONTEND_VERSION-$BACKEND_VERSION"
+          export FULL_IMAGE_TAG="${{ env.REGISTRY }}/concordium/$IMAGE_NAME:$BACKEND_VERSION"
           echo "::notice FULL_IMAGE_TAG=${FULL_IMAGE_TAG}"
           # Make sure the image does not exist. Abort if we can retrieve any metadata.
           if docker manifest inspect ${FULL_IMAGE_TAG} > /dev/null; then
@@ -50,9 +47,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          file: ./dockerfiles/server.Dockerfile
+          file: ./dockerfiles/indexer.Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tag }}
-        build-args:
-          SPONSORED_TRANSACTION_BACKEND_BASE_URL: ${{ SPONSORED_TRANSACTION_BACKEND_BASE_URL }}

--- a/.github/workflows/release-track-and-trace-indexer-docker.yml
+++ b/.github/workflows/release-track-and-trace-indexer-docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          file: ./dockerfiles/indexer.Dockerfile
+          file: ./trackAndTrace/dockerfiles/indexer.Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tag }}

--- a/.github/workflows/release-track-and-trace-indexer-docker.yml
+++ b/.github/workflows/release-track-and-trace-indexer-docker.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
-          context: .
+          context: ./trackAndTrace
           file: ./trackAndTrace/dockerfiles/indexer.Dockerfile
           push: true
           platforms: linux/amd64

--- a/.github/workflows/release-track-and-trace-server-docker.yml
+++ b/.github/workflows/release-track-and-trace-server-docker.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
-          context: .
+          context: ./trackAndTrace
           file: ./trackAndTrace/dockerfiles/server.Dockerfile
           push: true
           platforms: linux/amd64

--- a/.github/workflows/release-track-and-trace-server-docker.yml
+++ b/.github/workflows/release-track-and-trace-server-docker.yml
@@ -13,7 +13,6 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: dapp-track-and-trace-server
-  SPONSORED_TRANSACTION_BACKEND_BASE_URL: "https://trackntrace.testnet.concordium.com:8000"
 
 jobs:
   build-and-push-image:
@@ -31,10 +30,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Extract version tag from package.json/Cargo.toml and the TRACK_AND_TRACE_CONTRACT_INDEX from the `.env` file
+      - name: Extract version tag from package.json/Cargo.toml
         id: meta
         run: |
-          export TRACK_AND_TRACE_CONTRACT_INDEX=$(grep -v '^#' .env | grep TRACK_AND_TRACE_CONTRACT_INDEX | cut -d '=' -f 2)
           export FRONTEND_VERSION=$(jq -r .version trackAndTrace/frontend/package.json)
           export BACKEND_VERSION=$(yq .package.version trackAndTrace/indexer/Cargo.toml)
           export FULL_IMAGE_TAG="${{ env.REGISTRY }}/concordium/$IMAGE_NAME:$FRONTEND_VERSION-$BACKEND_VERSION"
@@ -44,19 +42,14 @@ jobs:
              echo "::error ${FULL_IMAGE_TAG} already exists"
              exit 1
           else
-             # Store the TRACK_AND_TRACE_CONTRACT_INDEX value into a track_and_trace_contract_index variable for the following step 
+             # Store the full image tag into a tag variable for the following step  
              echo "tag=${FULL_IMAGE_TAG}" > "$GITHUB_OUTPUT"
-             # Store the full image tag into a tag variable for the following step 
-             echo "track_and_trace_contract_index=${TRACK_AND_TRACE_CONTRACT_INDEX}" > "$GITHUB_OUTPUT"
           fi
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          file: ./dockerfiles/server.Dockerfile
+          file: ./trackAndTrace/dockerfiles/server.Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tag }}
-        build-args:
-          SPONSORED_TRANSACTION_BACKEND_BASE_URL: ${{ SPONSORED_TRANSACTION_BACKEND_BASE_URL }}
-          TRACK_AND_TRACE_CONTRACT_INDEX: ${{ steps.meta.outputs.track_and_trace_contract_index }}

--- a/.github/workflows/release-track-and-trace-server-docker.yml
+++ b/.github/workflows/release-track-and-trace-server-docker.yml
@@ -1,0 +1,62 @@
+# This job builds and publishes the docker image for the track and trace server to
+# the dockerhub image repository.
+name: Create and publish the docker image for the track and trace server.
+
+on:
+  workflow_dispatch: # allows manual trigger
+
+  push:
+    tags:
+      # The `server` uses the versioning convention: `frontend_version-backend_version`. 
+      - 'track-and-trace/*.*.*-*.*.*'   
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: dapp-track-and-trace-server
+  SPONSORED_TRANSACTION_BACKEND_BASE_URL: "https://trackntrace.testnet.concordium.com:8000"
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    environment: track-and-trace
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      # Uses the `docker/login-action` action to log in to the Container registry.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract version tag from package.json/Cargo.toml and the TRACK_AND_TRACE_CONTRACT_INDEX from the `.env` file
+        id: meta
+        run: |
+          export TRACK_AND_TRACE_CONTRACT_INDEX=$(grep -v '^#' .env | grep TRACK_AND_TRACE_CONTRACT_INDEX | cut -d '=' -f 2)
+          export FRONTEND_VERSION=$(jq -r .version trackAndTrace/frontend/package.json)
+          export BACKEND_VERSION=$(yq .package.version trackAndTrace/indexer/Cargo.toml)
+          export FULL_IMAGE_TAG="${{ env.REGISTRY }}/concordium/$IMAGE_NAME:$FRONTEND_VERSION-$BACKEND_VERSION"
+          echo "::notice FULL_IMAGE_TAG=${FULL_IMAGE_TAG}"
+          # Make sure the image does not exist. Abort if we can retrieve any metadata.
+          if docker manifest inspect ${FULL_IMAGE_TAG} > /dev/null; then
+             echo "::error ${FULL_IMAGE_TAG} already exists"
+             exit 1
+          else
+             # Store the TRACK_AND_TRACE_CONTRACT_INDEX value into a track_and_trace_contract_index variable for the following step 
+             echo "tag=${FULL_IMAGE_TAG}" > "$GITHUB_OUTPUT"
+             # Store the full image tag into a tag variable for the following step 
+             echo "track_and_trace_contract_index=${TRACK_AND_TRACE_CONTRACT_INDEX}" > "$GITHUB_OUTPUT"
+          fi
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: ./dockerfiles/server.Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tag }}
+        build-args:
+          SPONSORED_TRANSACTION_BACKEND_BASE_URL: ${{ SPONSORED_TRANSACTION_BACKEND_BASE_URL }}
+          TRACK_AND_TRACE_CONTRACT_INDEX: ${{ steps.meta.outputs.track_and_trace_contract_index }}

--- a/.github/workflows/release-track-and-trace-server-docker.yml
+++ b/.github/workflows/release-track-and-trace-server-docker.yml
@@ -8,7 +8,7 @@ on:
   push:
     tags:
       # The `server` uses the versioning convention: `frontend_version-backend_version`. 
-      - 'track-and-trace/*.*.*-*.*.*'   
+      - 'track-and-trace/server/*.*.*-*.*.*'   
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
+++ b/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
@@ -1,0 +1,53 @@
+# This job builds and publishes the docker image for the track and trace sponsored transaction service to
+# the dockerhub image repository.
+name: Create and publish the docker image for the track and trace sponsored transaction service.
+
+on:
+  workflow_dispatch: # allows manual trigger
+
+  push:
+    tags:
+      - 'track-and-trace/*.*.*'   
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: dapp-track-and-trace-sponsored-transaction-service
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    environment: track-and-trace
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      # Uses the `docker/login-action` action to log in to the Container registry.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract version tag from Cargo.toml
+        id: meta
+        run: |
+          export BACKEND_VERSION=$(yq .package.version trackAndTrace/sponsored-transaction-service/Cargo.toml)
+          export FULL_IMAGE_TAG="${{ env.REGISTRY }}/concordium/$IMAGE_NAME:$BACKEND_VERSION"
+          echo "::notice FULL_IMAGE_TAG=${FULL_IMAGE_TAG}"
+          # Make sure the image does not exist. Abort if we can retrieve any metadata.
+          if docker manifest inspect ${FULL_IMAGE_TAG} > /dev/null; then
+             echo "::error ${FULL_IMAGE_TAG} already exists"
+             exit 1
+          else
+             # Store the full image tag into a tag variable for the following step.
+             echo "tag=${FULL_IMAGE_TAG}" > "$GITHUB_OUTPUT"
+          fi
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: ./dockerfiles/server.Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tag }}

--- a/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
+++ b/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          file: ./dockerfiles/server.Dockerfile
+          file: ./trackAndTrace/dockerfiles/server.Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tag }}

--- a/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
+++ b/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
@@ -7,7 +7,7 @@ on:
 
   push:
     tags:
-      - 'track-and-trace/*.*.*'   
+      - 'track-and-trace/sponsored-transaction-service/*.*.*'   
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
+++ b/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
-          context: .
+          context: ./trackAndTrace
           file: ./trackAndTrace/dockerfiles/server.Dockerfile
           push: true
           platforms: linux/amd64

--- a/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
+++ b/.github/workflows/release-track-and-trace-sponsored-transaction-service-docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: ./trackAndTrace
-          file: ./trackAndTrace/dockerfiles/server.Dockerfile
+          file: ./trackAndTrace/dockerfiles/sponsored-transaction-service.Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Purpose

Add various release GitHub actions that publish the track and trace images to the docker hub.

Depends on https://github.com/Concordium/concordium-dapp-examples/pull/64

## Changes

- Add release GitHub action for server
- Add release GitHub action for indexer
- Add release GitHub action for sponsored-transaction-service