### PR TITLE
Update sponsoredTransaction backend with contract client

### DIFF
--- a/sponsoredTransactions/backend/CHANGELOG.md
+++ b/sponsoredTransactions/backend/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 
+- Change to use the `contract-client` from the Rust SDK.
+- Add reject reason decoding of reverted transactions during the dry-run.
+
 ## 2.0.0
 
 - Use `AccountSignatures` type for the input parameter to the `permit` function. The sponsored transaction smart contract uses the `check_account_signature` host function with the `AccountSignatures` type as input parameter to verify signatures in the smart contract now.

--- a/sponsoredTransactions/backend/README.md
+++ b/sponsoredTransactions/backend/README.md
@@ -16,18 +16,18 @@ All of the above is available by using `--help` to get usage information.
 
 An example to run the backend with basic settings and testnet node would be:
 ```shell
-cargo run -- --node http://node.testnet.concordium.com:20000 --account <YourAccountPathToYourKeys> --smart-contract-index 4184
+cargo run -- --node http://node.testnet.concordium.com:20000 --account <YourAccountPathToYourKeys> --smart-contract-index 9586
 ```
 
 An example to run the backend with some filled in example settings would be:
 
 ```shell
-cargo run -- --node http://node.testnet.concordium.com:20000 --port 8080 --account ./3PXwJYYPf6fyVb4GJquxSZU8puxrHfzc4XogdMVot8MUQK53tW.export --public-folder ../frontend/dist --smart-contract-index 4184
+cargo run -- --node http://node.testnet.concordium.com:20000 --port 8080 --account ./4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export --public-folder ../frontend/dist --smart-contract-index 9586
 ```
 
-To get your account file (the `3PXwJYYPf6fyVb4GJquxSZU8puxrHfzc4XogdMVot8MUQK53tW.export` file in the above example), export it from the Concordium Browser wallet for web.
-This account should be only used for this service. No transactions should be sent from the account by any other means to ensure the account nonce is tracked 
-correctly in the service (e.g. don't use the `3PXwJYYPf6fyVb4GJquxSZU8puxrHfzc4XogdMVot8MUQK53tW` account in the browser wallet to send transactions via the front end).
+To get your account file (the `4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX.export` file in the above example), export it from the Concordium Browser wallet for web.
+This account should be only used for this service. No transactions should be sent from the account by any other means to ensure the account nonce is tracked
+correctly in the service (e.g. don't use the `4SizPU2ipqQQza9Xa6fUkQBCDjyd1vTNUNDGbBeiRGpaJQc6qX` account in the browser wallet to send transactions via the front end).
 
 <img src="./pic/pic1.png"  width="200" />
 <img src="./pic/pic2.png"  width="200" />

--- a/sponsoredTransactions/frontend/package.json
+++ b/sponsoredTransactions/frontend/package.json
@@ -53,7 +53,7 @@
         "lint-fix": "yarn lint --fix",
         "fmt": "prettier --write .",
         "type:check": "yarn run tsc --noEmit",
-        "build": "SMART_CONTRACT_INDEX=6372 tsx ./esbuild.config.ts; cp ./src/assets/* ./dist",
+        "build": "SMART_CONTRACT_INDEX=9586 tsx ./esbuild.config.ts; cp ./src/assets/* ./dist",
         "watch": "cross-env WATCH=1 yarn build",
         "start": "live-server ./dist"
     }


### PR DESCRIPTION
## Purpose

related https://github.com/Concordium/concordium-dapp-examples/pull/87


## Changes

- Change to use the `contract-client` from the Rust SDK.
- Add reject reason decoding of reverted transactions during the dry-run.
- `Internal errors` occurring when querying the node are not reported to the front end anymore (might leak some information of the backend node connection) but full logging is done at the backend of any `internal error`.