### PR TITLE
Use verify account signature function from SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following examples are available.
   interactions of a store that sells restricted items, and supports payment in
   EUROe tokens (or generally any CIS2 token).
 
-- [track-and-trace](./track-and-trace/) demonstrates an example frontend, backend, smart contract and event indexer to track items along the supply chain. It also has a [CIS-3](https://proposals.concordium.software/CIS/cis-3.html) sponsored transactions service that is compatible with any CIS-3 contract.
+- [trackAndTrace](./trackAndTrace/) demonstrates an example frontend, backend, smart contract and event indexer to track items along the supply chain. It also has a [CIS-3](https://proposals.concordium.software/CIS/cis-3.html) sponsored transactions service that is compatible with any CIS-3 contract.
 
 - [compliant-reward-distribution](./compliant-reward-distribution/) demonstrates an airdrop example with an indexer, a frontend, and a backend with signature and ZK proof verification at the backend. The ZK proof is used to ensure `Sybil-resistance/uniqueness` as each identity on the chain can interact with the service with only one of its accounts.
 

--- a/compliant-reward-distribution/README.md
+++ b/compliant-reward-distribution/README.md
@@ -6,7 +6,7 @@
 
 ## Hosted front end
 
-[Soon](https://github.com/Concordium/concordium-dapp-examples)
+[here](https://compliant-reward-distribution.testnet.concordium.com/)
 
 ## Overview
 

--- a/compliant-reward-distribution/indexer-and-server/CHANGELOG.md
+++ b/compliant-reward-distribution/indexer-and-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 0.1.1
+
+- Change to use the new `verify_single_account_signature` function from the SDK.
+
 ## 0.1.0
 
 -   Add initial `server`.

--- a/compliant-reward-distribution/indexer-and-server/CHANGELOG.md
+++ b/compliant-reward-distribution/indexer-and-server/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.1.1
 
-- Change to use the new `verify_single_account_signature` function from the SDK.
+-   Change to use the new `verify_single_account_signature` function from the SDK.
+-   Update submodule link.
 
 ## 0.1.0
 

--- a/compliant-reward-distribution/indexer-and-server/Cargo.lock
+++ b/compliant-reward-distribution/indexer-and-server/Cargo.lock
@@ -691,7 +691,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -1515,7 +1515,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/compliant-reward-distribution/indexer-and-server/Cargo.toml
+++ b/compliant-reward-distribution/indexer-and-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/compliant-reward-distribution/indexer-and-server/src/bin/server.rs
+++ b/compliant-reward-distribution/indexer-and-server/src/bin/server.rs
@@ -534,7 +534,7 @@ where
     let SigningData {
         signer,
         message,
-       signature,
+        signature,
         block_height,
     } = param.signing_data();
 

--- a/gallery/CHANGELOG.md
+++ b/gallery/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+-   Update submodule link.
+
 ## 0.2.0
 
 -   Bump `@concordium/web-sdk` to version `7.5.1`.

--- a/gallery/verifier/Cargo.lock
+++ b/gallery/verifier/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/sponsoredTransactions/backend/CHANGELOG.md
+++ b/sponsoredTransactions/backend/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Change to use the `contract-client` from the Rust SDK.
 - Add reject reason decoding of reverted transactions during the dry-run.
+- Update submodule link.
 
 ## 2.0.0
 

--- a/sponsoredTransactions/backend/Cargo.lock
+++ b/sponsoredTransactions/backend/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/sponsoredTransactionsAuction/backend/CHANGELOG.md
+++ b/sponsoredTransactionsAuction/backend/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+- Update submodule link.
+
 ## 1.0.0
 
 - Initial auction sponsored transaction back end.

--- a/sponsoredTransactionsAuction/backend/Cargo.lock
+++ b/sponsoredTransactionsAuction/backend/Cargo.lock
@@ -689,7 +689,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/trackAndTrace/sponsored-transaction-service/CHANGELOG.md
+++ b/trackAndTrace/sponsored-transaction-service/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased changes
 
 - Decode the reject reason of a failed transaction during the dry-run at the `sponsored_transaction_service` backend.
+- Update submodule link.
 
 ## 1.0.0
 

--- a/trackAndTrace/sponsored-transaction-service/Cargo.lock
+++ b/trackAndTrace/sponsored-transaction-service/Cargo.lock
@@ -711,7 +711,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",


### PR DESCRIPTION
## Purpose

Use the new `verify_single_account_signature` function from the SDK.

## Changes

- Change to use the new `verify_single_account_signature` function from the SDK.
- Update the submodule link to the Rust SDK.
- Fix small typos.
- Add the hosted front-end URL to the READ.me.
