### PR TITLE
Fix ipfs:// prefix issue

### DIFF
--- a/low-code-nft-marketplace/common-ui/src/models/PinataClient.ts
+++ b/low-code-nft-marketplace/common-ui/src/models/PinataClient.ts
@@ -1,7 +1,7 @@
 import { default as axios } from 'axios';
 
 export class PinataClient {
-    constructor(private pinataJwt: string) {}
+    constructor(private pinataJwt: string) { }
 
     async isJwtValid(): Promise<boolean> {
         const response = await axios({
@@ -33,7 +33,10 @@ export class PinataClient {
         }
 
         const responseData = response.data as PinFileToIPFSResponse;
-        return `ipfs://${responseData.IpfsHash}`;
+        // usually platforms should handle the gateway OR prefix usage but wallet doesnt at the moment.
+        // since this is an example, we can use it like below.
+        return `https://ipfs.io/ipfs/${responseData.IpfsHash}`
+        // return `ipfs://${responseData.IpfsHash}`;
     }
 
     async uploadJson(json: object, fileName: string): Promise<string> {
@@ -60,7 +63,10 @@ export class PinataClient {
         }
 
         const responseData = response.data as PinFileToIPFSResponse;
-        return `ipfs://${responseData.IpfsHash}`;
+        // usually platforms should handle the gateway OR prefix usage but wallet doesnt at the moment.
+        // since this is an example, we can use it like below.
+        return `https://ipfs.io/ipfs/${responseData.IpfsHash}`
+        // return `ipfs://${responseData.IpfsHash}`;
     }
 }
 

--- a/low-code-nft-marketplace/market-ui/src/Constants.ts
+++ b/low-code-nft-marketplace/market-ui/src/Constants.ts
@@ -7,7 +7,7 @@ import { ModuleReference } from '@concordium/web-sdk';
  * Contract Address for Marketplace. You should specify your contract's index when you initialized it.
  */
 export const MARKET_CONTRACT_ADDRESS = {
-    index: BigInt(5987),
+    index: BigInt(10491),
     subindex: BigInt(0),
 };
 
@@ -36,7 +36,7 @@ export const CIS2_MULTI_CONTRACT_INFO: Cis2ContractInfo = {
     moduleRef: new ModuleReference(MULTI_CONTRACT_MODULE_REF),
     tokenIdByteSize: 1,
 };
-export const IPFS_GATEWAY_URL = 'https://gateway.pinata.cloud/ipfs/';
+export const IPFS_GATEWAY_URL = 'https://ipfs.io/ipfs/';
 
 // Default value of the new marketplace contract init flag is false.
 // It needs to be set as true in order to allow to create a new marketplace contract instance

--- a/low-code-nft-marketplace/market-ui/src/components/cis2/LazyCis2Metadata.tsx
+++ b/low-code-nft-marketplace/market-ui/src/components/cis2/LazyCis2Metadata.tsx
@@ -32,7 +32,7 @@ function LazyCis2Metadata(props: {
                 });
             });
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.metadataUrl.url]);
+    }, [toIpfsGatewayUrl(props.metadataUrl.url)]);
 
     if (state.error) {
         return props.errorLoadingTemplate(state.error.toString());

--- a/low-code-nft-marketplace/tsconfig.json
+++ b/low-code-nft-marketplace/tsconfig.json
@@ -3,9 +3,14 @@
         "jsx": "react-jsx",
         "esModuleInterop": true,
         "target": "ES2021",
-        "lib": ["dom", "dom.iterable", "esnext"],
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
         "moduleResolution": "Node",
-        "outDir": "dist"
+        "outDir": "dist",
+        "strict": true
     },
     "references": [
         {
@@ -18,6 +23,12 @@
             "path": "./mint-ui/tsconfig.json"
         }
     ],
-    "include": ["./common-ui/src/**/*", "./market-ui/src/**/*", "./mint-ui/src/**/*"],
-    "exclude": ["./node_modules"]
+    "include": [
+        "./common-ui/src/**/*",
+        "./market-ui/src/**/*",
+        "./mint-ui/src/**/*"
+    ],
+    "exclude": [
+        "./node_modules"
+    ]
 }


### PR DESCRIPTION
## Purpose

Ideally, the browser wallet should not rely on a gateway for IPFS (like https://ipfs.io). The right way is to host the metadata on ipfs:// only without giving any gateways on-chain. Cause when that gateway is down, then you cant access your token, it makes your data centralized in a way. 
But when metadata is hosted on IPFS and a token is minted with only the prefix ipfs://Qmsomehash then BW validation checks fail. A ticket is created and when BW addresses this we may change it back, but at the moment this causes confusion in people

## Changes
Its a fix for changing "ipfs://" to "https://ipfs.io/ipfs/QmHASH" 

_Describe the changes that were needed.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
