### PR TITLE
Fix the ipfs prefix problem by adding https://ipfs.io/ipfs

### DIFF
--- a/low-code-nft-marketplace/common-ui/src/models/PinataClient.ts
+++ b/low-code-nft-marketplace/common-ui/src/models/PinataClient.ts
@@ -33,7 +33,10 @@ export class PinataClient {
         }
 
         const responseData = response.data as PinFileToIPFSResponse;
-        return `ipfs://${responseData.IpfsHash}`;
+        // usually platforms(wallets) should handle the gateway OR prefix usage but wallet doesnt at the moment.
+        // since this is an example, we can use it like below.
+        return `https://ipfs.io/ipfs/${responseData.IpfsHash}`;
+        // return `ipfs://${responseData.IpfsHash}`;
     }
 
     async uploadJson(json: object, fileName: string): Promise<string> {
@@ -60,7 +63,10 @@ export class PinataClient {
         }
 
         const responseData = response.data as PinFileToIPFSResponse;
-        return `ipfs://${responseData.IpfsHash}`;
+        // usually platforms(wallets) should handle the gateway OR prefix usage but wallet doesnt at the moment.
+        // since this is an example, we can use it like below.
+        return `https://ipfs.io/ipfs/${responseData.IpfsHash}`;
+        // return `ipfs://${responseData.IpfsHash}`;
     }
 }
 

--- a/low-code-nft-marketplace/market-ui/src/Constants.ts
+++ b/low-code-nft-marketplace/market-ui/src/Constants.ts
@@ -36,7 +36,7 @@ export const CIS2_MULTI_CONTRACT_INFO: Cis2ContractInfo = {
     moduleRef: new ModuleReference(MULTI_CONTRACT_MODULE_REF),
     tokenIdByteSize: 1,
 };
-export const IPFS_GATEWAY_URL = 'https://gateway.pinata.cloud/ipfs/';
+export const IPFS_GATEWAY_URL = 'https://ipfs.io/ipfs/';
 
 // Default value of the new marketplace contract init flag is false.
 // It needs to be set as true in order to allow to create a new marketplace contract instance

--- a/low-code-nft-marketplace/mint-ui/src/Constants.ts
+++ b/low-code-nft-marketplace/mint-ui/src/Constants.ts
@@ -12,7 +12,7 @@ export const CIS2_MULTI_CONTRACT_INFO: Cis2ContractInfo = {
     moduleRef: new ModuleReference(MULTI_CONTRACT_MODULE_REF),
     tokenIdByteSize: 1,
 };
-export const IPFS_GATEWAY_URL = 'https://gateway.pinata.cloud/ipfs/';
+export const IPFS_GATEWAY_URL = 'https://ipfs.io/ipfs/';
 
 export const CONNCORDIUM_NODE_ENDPOINT = 'https://grpc.testnet.concordium.com';
 export const CONCORDIUM_NODE_PORT = 20000;


### PR DESCRIPTION
## Purpose
Ideally, the browser wallet should not rely on a gateway for IPFS (like https://ipfs.io/). The right way is to host the metadata on ipfs:// only without giving any gateways on-chain. Cause when that gateway is down, then you cant access your token, it makes your data centralized in a way.
But when metadata is hosted on IPFS and a token is minted with only the prefix ipfs://Qmsomehash then BW validation checks fail. A ticket is created and when BW addresses this we may change it back, but at the moment this causes confusion in people
_Describe the purpose of the pull request, link to issue describing the problem, etc.

## Changes
Its a fix for changing "ipfs://" to "https://ipfs.io/ipfs/QmHASH"
_Describe the changes that were needed.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
