### PR TITLE
Extend `trackAndTrace` example to parse return values

### DIFF
--- a/trackAndTrace/test-scripts/Cargo.lock
+++ b/trackAndTrace/test-scripts/Cargo.lock
@@ -527,9 +527,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -537,7 +537,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -608,9 +608,8 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f49ffe8ff944ec174f597b3f0d1f84e77e6dd3e8eb2fad3bdd08c8d1dcf7c9"
+version = "9.2.0"
+source = "git+https://github.com/concordium/concordium-rust-sdk#f06dfa45ba72ea161cef759dfcf308c5a8404093"
 dependencies = [
  "base64",
  "bs58",
@@ -630,9 +629,8 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9db2f3ebe6616b1658ec10acc3e9ca31f65824e3ab5ad88f3cf2532e25aed2"
+version = "4.1.0"
+source = "git+https://github.com/concordium/concordium-rust-sdk#f06dfa45ba72ea161cef759dfcf308c5a8404093"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -641,9 +639,8 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129ba5797981e1b1a22f52807087ca5b018cbe27b8932df4c963be21419d5753"
+version = "6.0.0"
+source = "git+https://github.com/concordium/concordium-rust-sdk#f06dfa45ba72ea161cef759dfcf308c5a8404093"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -674,9 +671,8 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23751642d6672291e4feac02252f5f1d258cd3c093873a7f59f3d9a7cc165f82"
+version = "6.0.0"
+source = "git+https://github.com/concordium/concordium-rust-sdk#f06dfa45ba72ea161cef759dfcf308c5a8404093"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -708,9 +704,8 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a581ef6ae1b23e149eaf5ed1e43c1da877ded9ae0de4989cd71b76d25c67d7"
+version = "5.0.0"
+source = "git+https://github.com/concordium/concordium-rust-sdk#f06dfa45ba72ea161cef759dfcf308c5a8404093"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -721,9 +716,8 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b92eba25481b3cec616943c433d780d1ca6db02cf2bc9be8d8d192d54dedb8"
+version = "7.0.0"
+source = "git+https://github.com/concordium/concordium-rust-sdk#f06dfa45ba72ea161cef759dfcf308c5a8404093"
 dependencies = [
  "aes",
  "anyhow",
@@ -770,12 +764,11 @@ dependencies = [
 [[package]]
 name = "concordium_base_derive"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a154e9a64d58d3e9f890c603df847b8685cfd0bac3fadd18498af539650bed"
+source = "git+https://github.com/concordium/concordium-rust-sdk#f06dfa45ba72ea161cef759dfcf308c5a8404093"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2770,6 +2763,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"

--- a/trackAndTrace/test-scripts/Cargo.toml
+++ b/trackAndTrace/test-scripts/Cargo.toml
@@ -7,8 +7,12 @@ edition = "2021"
 anyhow = "1.0"
 chrono = "0.4"
 clap = { version = "4.4", features = ["env", "derive"] }
-concordium-rust-sdk = { version = "4.1"}
+concordium-rust-sdk = { git = "https://github.com/concordium/concordium-rust-sdk"}
 tokio = { version = "1.35", features = ["rt-multi-thread", ] }
 tonic = { version = "0.10", features = ["tls", "tls-roots"] }
 track-and-trace = { path = "../smart-contract/", default-features = false, features = ["std", "serde"] }
 serde_json = "1.0"
+
+[patch.crates-io]
+concordium-contracts-common = { git = "https://github.com/concordium/concordium-rust-sdk"}
+concordium-contracts-common-derive = { git = "https://github.com/concordium/concordium-rust-sdk"}

--- a/trackAndTrace/test-scripts/README.md
+++ b/trackAndTrace/test-scripts/README.md
@@ -57,18 +57,66 @@ To get your account file (the `4bbdAUCDK2D6cUvUeprGr4FaSaHXKuYmYVjyCa4bXSCu3NUXz
 The script will run a series of transactions. The output will be similar to:
 
 ```
-Starting script with admin account 4bbdAUCDK2D6cUvUeprGr4FaSaHXKuYmYVjyCa4bXSCu3NUXzA.
-Source module with reference f94a1503030142b4dfdd6667875403783e6f457eafb020f0a957270cfe7499e9 already exists.
-The maximum amount of NRG allowed for the transaction is 4075.
-Transaction a2cc66c2e674af64e5a7b85ec1b97e87f9433a21f5ffdc795c038c0f7195a712 submitted. Waiting for finalization.
-Initialized a new smart contract instance at address <8021,0>.
-Submitted create item with index 0 in transaction 15f6cfe148a65cc621fba6164326466702d35df14b5dac07d35bd40b0354e9a1.
-Submitted create item with index 1 in transaction db037444d4d619f5bfb195bdc7532d933120873a517dae5b87dad754da24a53d.
-Submitted update item status with index 0 to `InTransit` in transaction fd2b2cbd9e9c0c1ed34306ed7fef2d698ce86465b4dbf13a1bb97538217a72b7.
-Submitted update item status with index 1 to `InTransit` in transaction 73af8cedac05f3dddde14b9358481892a5c1923457dbd6e6c6e920fb5a35ccef.
-Submitted update item status with index 0 to `InStore` in transaction hash 94cff0ec86bdfe059299798ee3aa7e62ed7b1e806ff55bdb397601d0044740c9.
-Submitted update item status with index 1 to `InStore` in transaction hash 718eb74c88429c59032e2e2367f570f66b6f16b87f9e86661e2ddaf3758c5d37.
-Submitted update item status with index 0 to `Sold` in transaction 88cc980eb9c58eccfa9d98605a7f463738ce17f8993cafbef2b17be17cdfe425.
-Submitted update item status with index 1 to `Sold` in transaction 8b8f0729ca0d8f4ca36dcd226b042f4baa5b98fce71effff31db52d90337a466.
+Starting script with admin account 3eQtum35Gkba7g6uePqr9Zc5iYKVaKKCeho7YcydTBJLvxdZgG.
+Source module with reference a5a2660cd12561cc2fe11411e840655453ff1cbdfe6bcfb91b5949c6ef9e84c5 already exists.
+The maximum amount of NRG allowed for the transaction is 2828.
+Transaction c29ea78ba1f26101fe18e5a8d2b7f8ccd5ec7729db31a38a4965e0b24fdc576f submitted. Waiting for finalization.
+Initialized a new smart contract instance at address <5090,0>.
+Submitted create item with index 0 in transaction e9c60ef7256fb0afa9ca4148ebade5827d2c0573e196e807c83b4dc58f1db13f.
+Submitted create item with index 1 in transaction d2365b4ce2f70fe79a668afc303c94912dc7a878e1ca5fae2611b64c3ac368aa.
+Item state for item with index 0 before transaction: ItemState {
+    status: Produced,
+    metadata_url: None,
+}
+Submitted update item status with index 0 to `InTransit` in transaction 89a6cf6a4a074991599a9640974828db64af982710b9e6018f094be8c3091889.
+Item state for item with index 0 after transaction: ItemState {
+    status: InTransit,
+    metadata_url: None,
+}
+Item state for item with index 1 before transaction: ItemState {
+    status: Produced,
+    metadata_url: None,
+}
+Submitted update item status with index 1 to `InTransit` in transaction d83e6e3a3b9d23e9afc46cee4f37618a57e39d092c32b7c1c4d00727e2242ba2.
+Item state for item with index 1 after transaction: ItemState {
+    status: InTransit,
+    metadata_url: None,
+}
+Item state for item with index 0 before transaction: ItemState {
+    status: InTransit,
+    metadata_url: None,
+}
+Submitted update item status with index 0 to `InStore` in transaction hash 5bf0af1674ecdd6b604f5b2cbeab154b95dc6b6ce6dc90dc86a4b76feab7070d.
+Item state for item with index 0 after transaction: ItemState {
+    status: InStore,
+    metadata_url: None,
+}
+Item state for item with index 1 before transaction: ItemState {
+    status: InTransit,
+    metadata_url: None,
+}
+Submitted update item status with index 1 to `InStore` in transaction hash d7950ac2876ebd21f3a789b01099c96ac633650be3895934b90287a909c9dfa6.
+Item state for item with index 1 after transaction: ItemState {
+    status: InStore,
+    metadata_url: None,
+}
+Item state for item with index 0 before transaction: ItemState {
+    status: InStore,
+    metadata_url: None,
+}
+Submitted update item status with index 0 to `Sold` in transaction 86f150c41f171617ac58a41f0525fe85ceb3533b269dd36383a317f45a137720.
+Item state for item with index 0 after transaction: ItemState {
+    status: Sold,
+    metadata_url: None,
+}
+Item state for item with index 1 before transaction: ItemState {
+    status: InStore,
+    metadata_url: None,
+}
+Submitted update item status with index 1 to `Sold` in transaction f0e687e09c13130ac8d372d1ba96da79ac48adeb964208a3e3e1e1d4f755f04d.
+Item state for item with index 1 after transaction: ItemState {
+    status: Sold,
+    metadata_url: None,
+}
 Script completed successfully
 ```

--- a/trackAndTrace/test-scripts/src/main.rs
+++ b/trackAndTrace/test-scripts/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use clap::Parser as _;
 use concordium_rust_sdk::{
     contract_client::{ContractInitBuilder, ModuleDeployBuilder, ViewError},
@@ -30,7 +30,7 @@ struct Args {
     module:                    std::path::PathBuf,
     #[arg(
         long = "input-parameter-file",
-        short = 'i',
+        short = 'p',
         help = "A JSON file containing the input parameter."
     )]
     input_parameter_json_file: std::path::PathBuf,
@@ -163,6 +163,24 @@ async fn main() -> anyhow::Result<()> {
             additional_data: AdditionalData::empty(),
         };
 
+        // Check the status of the item before the transaction
+        let tx_dry_run = contract_client
+            .dry_run_update::<ItemID, ViewError>(
+                "getItemState",
+                Amount::zero(),
+                admin_key.address,
+                &ItemID::from(i),
+            )
+            .await?;
+
+        eprintln!(
+            "Item state for item with index {i} before transaction: {:#?}",
+            tx_dry_run
+                .return_value()
+                .ok_or(anyhow!("Failed to get return value"))?
+                .parse::<ItemState>()?
+        );
+
         let tx_dry_run = contract_client
             .dry_run_update::<ChangeItemStatusParams<AdditionalData>, ViewError>(
                 "changeItemStatus",
@@ -181,10 +199,45 @@ async fn main() -> anyhow::Result<()> {
         if let Err(err) = tx_hash.wait_for_finalization().await {
             anyhow::bail!("Update item status failed: {err:#?}.");
         }
+
+        // Check the status of the item after the transaction
+        let tx_dry_run = contract_client
+            .dry_run_update::<ItemID, ViewError>(
+                "getItemState",
+                Amount::zero(),
+                admin_key.address,
+                &ItemID::from(i),
+            )
+            .await?;
+        eprintln!(
+            "Item state for item with index {i} after transaction: {:#?}",
+            tx_dry_run
+                .return_value()
+                .ok_or(anyhow!("Failed to get return value"))?
+                .parse::<ItemState>()?
+        );
     }
 
     // Update items from `InTransit` to `InStore`
     for i in 0..args.num_items {
+        // Check the status of the item before the transaction
+        let tx_dry_run = contract_client
+            .dry_run_update::<ItemID, ViewError>(
+                "getItemState",
+                Amount::zero(),
+                admin_key.address,
+                &ItemID::from(i),
+            )
+            .await?;
+
+        eprintln!(
+            "Item state for item with index {i} before transaction: {:#?}",
+            tx_dry_run
+                .return_value()
+                .ok_or(anyhow!("Failed to get return value"))?
+                .parse::<ItemState>()?
+        );
+
         let param: ChangeItemStatusParams<AdditionalData> = ChangeItemStatusParams {
             item_id:         ItemID::from(i),
             new_status:      Status::InStore,
@@ -210,10 +263,45 @@ async fn main() -> anyhow::Result<()> {
         if let Err(err) = tx_hash.wait_for_finalization().await {
             anyhow::bail!("Update item status failed: {err:#?}.");
         }
+
+        // Check the status of the item after the transaction
+        let tx_dry_run = contract_client
+            .dry_run_update::<ItemID, ViewError>(
+                "getItemState",
+                Amount::zero(),
+                admin_key.address,
+                &ItemID::from(i),
+            )
+            .await?;
+        eprintln!(
+            "Item state for item with index {i} after transaction: {:#?}",
+            tx_dry_run
+                .return_value()
+                .ok_or(anyhow!("Failed to get return value"))?
+                .parse::<ItemState>()?
+        );
     }
 
     // Update items from `InStore` to `Sold`
     for i in 0..args.num_items {
+        // Check the status of the item before the transaction
+        let tx_dry_run = contract_client
+            .dry_run_update::<ItemID, ViewError>(
+                "getItemState",
+                Amount::zero(),
+                admin_key.address,
+                &ItemID::from(i),
+            )
+            .await?;
+
+        eprintln!(
+            "Item state for item with index {i} before transaction: {:#?}",
+            tx_dry_run
+                .return_value()
+                .ok_or(anyhow!("Failed to get return value"))?
+                .parse::<ItemState>()?
+        );
+
         let param: ChangeItemStatusParams<AdditionalData> = ChangeItemStatusParams {
             item_id:         ItemID::from(i),
             new_status:      Status::Sold,
@@ -238,6 +326,23 @@ async fn main() -> anyhow::Result<()> {
         if let Err(err) = tx_hash.wait_for_finalization().await {
             anyhow::bail!("Update item status failed: {err:#?}.");
         }
+
+        // Check the status of the item after the transaction
+        let tx_dry_run = contract_client
+            .dry_run_update::<ItemID, ViewError>(
+                "getItemState",
+                Amount::zero(),
+                admin_key.address,
+                &ItemID::from(i),
+            )
+            .await?;
+        eprintln!(
+            "Item state for item with index {i} after transaction: {:#?}",
+            tx_dry_run
+                .return_value()
+                .ok_or(anyhow!("Failed to get return value"))?
+                .parse::<ItemState>()?
+        );
     }
 
     eprintln!("Script completed successfully");


### PR DESCRIPTION
This pull request enhances the 'Track and Trace' example to showcase the newly implemented parse method for return values. The updated example provides a practical demonstration of how to use this method for deserialization of contract invocation results.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
