### PR TITLE
Remove DOCKER_CONTEXT_PATH

### DIFF
--- a/.github/workflows/release-allowlist-frontend.yaml
+++ b/.github/workflows/release-allowlist-frontend.yaml
@@ -13,5 +13,4 @@ jobs:
       BUILD_ARGS: |
         build_image=node:18-slim
       DOCKER_FILE_PATH: allowListManagerFaucet/frontend/Dockerfile
-      DOCKER_CONTEXT_PATH: allowListManagerFaucet/frontend
     secrets: inherit

--- a/.github/workflows/release-allowlist-manager-backend.yaml
+++ b/.github/workflows/release-allowlist-manager-backend.yaml
@@ -13,5 +13,4 @@ jobs:
       BUILD_ARGS: |
         build_image=node:18-slim
       DOCKER_FILE_PATH: allowListManagerFaucet/backend/Dockerfile
-      DOCKER_CONTEXT_PATH: allowListManagerFaucet/backend
     secrets: inherit

--- a/.github/workflows/release-allowlist-manager-verifier.yaml
+++ b/.github/workflows/release-allowlist-manager-verifier.yaml
@@ -13,5 +13,4 @@ jobs:
       BUILD_ARGS: |
         build_image=node:18-slim
       DOCKER_FILE_PATH: allowListManagerFaucet/services/web3id-verifier-ts/Dockerfile
-      DOCKER_CONTEXT_PATH: allowListManagerFaucet/services/web3id-verifier-ts
     secrets: inherit


### PR DESCRIPTION
## Purpose

Remove DOCKER_CONTEXT_PATH var from release flow as the reusable workflow doesn't use it

## Changes

DOCKER_CONTEXT_PATH removed from allowlist release flows

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
