### PR TITLE
Add build script to inject env vars at runtime

### DIFF
--- a/allowListManagerFaucet/frontend/Dockerfile
+++ b/allowListManagerFaucet/frontend/Dockerfile
@@ -1,8 +1,12 @@
 # syntax=docker/dockerfile:1
 ARG build_image="node:18-slim"
-FROM ${build_image} AS build
+FROM ${build_image}
 ARG build_image
-WORKDIR /build
+
+WORKDIR /app
+
+# Install serve package globally
+RUN npm install -g serve
 
 # Copy package files first for better caching
 COPY package.json package-lock.json* ./
@@ -17,19 +21,13 @@ COPY index.html ./
 COPY src/ ./src/
 COPY public/ ./public/
 
-# Build the application (now with environment variables available)
-RUN npm run build
-LABEL build_image=${build_image}
-
-# Use Node.js to serve static files
-FROM node:24-slim AS runtime
-WORKDIR /app
-
-# Install serve package globally
-RUN npm install -g serve
-
-# Copy built application
-COPY --from=build /build/dist ./
+# Copy the build and serve script
+COPY build-and-serve.sh ./
+RUN chmod +x build-and-serve.sh
 
 EXPOSE 3000
-CMD ["serve", "-s", ".", "-l", "3000"]
+
+# Use the script to build and serve at runtime
+CMD ["./build-and-serve.sh"]
+
+LABEL build_image=${build_image}

--- a/allowListManagerFaucet/frontend/build-and-serve.sh
+++ b/allowListManagerFaucet/frontend/build-and-serve.sh
@@ -8,7 +8,7 @@ echo "BACKEND_URL: ${BACKEND_URL}"
 # Build the application with runtime environment variables
 npm run build
 
-echo "Build completed. Starting server..."
+echo "Build completed.Starting server..."
 
 # Serve the built application
 serve -s dist -l 3000

--- a/allowListManagerFaucet/frontend/build-and-serve.sh
+++ b/allowListManagerFaucet/frontend/build-and-serve.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+echo "Building application with runtime environment variables..."
+echo "TOKEN_ID: ${TOKEN_ID}"
+echo "BACKEND_URL: ${BACKEND_URL}"
+
+# Build the application with runtime environment variables
+npm run build
+
+echo "Build completed. Starting server..."
+
+# Serve the built application
+serve -s dist -l 3000


### PR DESCRIPTION
## Purpose

Refactor frontend build to support runtime environment variables


## Changes

- Move from build-time to runtime environment variable injection
- Add build-and-serve.sh script that builds then serves the application
- Switch from multi-stage to single-stage Dockerfile for runtime builds
- Environment variables (TOKEN_ID, BACKEND_URL) now configured at deployment time
- Enables single image for multiple environments

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
