### PR TITLE
fix: update docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,24 +6,82 @@ on:
 
   pull_request:
     branches: main
+    paths:
+      - 'compliant-reward-distribution/**'
+      - 'euroe-demo/**'
+      - 'signMessage/**'
+      - 'simpleAgeVerification/**'
+      - 'gallery/**' 
+      - 'deps/concordium-rust-sdk'
+      - 'sponsoredTransactions/**'
+      - 'sponsoredTransactionsAuction/**'
+      - 'trackAndTrace/**'
+      - '!**.md'
 
   workflow_dispatch: # allows manual trigger
 
+# These get updated conditionally for specific apps
+# The build process slightly differs between them.
+env:
+  DOCKER_DIR: '.'
+  DOCKERFILE_DIR: '.'
+
 jobs:
-  build:
-    name: Building Docker Containers
-    # Don't run on draft pull requests
+  changes:
+    name: detect what files changed
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      docker-changes: ${{ steps.docker-changes.outputs.changes }}
+      compose-changes: ${{ steps.compose-changes.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for backend file changes for Docker builds
+        uses: dorny/paths-filter@v3.0.2
+        id: docker-changes
+        with:
+          filters: |
+            euroe-demo:
+              - 'euroe-demo/**'
+            gallery:
+              - 'gallery/**'
+              - 'deps/concordium-rust-sdk'
+            simpleAgeVerification:
+              - 'simpleAgeVerification/**'
+            signMessage:
+              - 'signMessage/**'
+            sponsoredTransactions:
+              - 'sponsoredTransactions/**'
+              - 'deps/concordium-rust-sdk'
+            sponsoredTransactionsAuction:
+              - 'sponsoredTransactionsAuction/**'
+              - 'deps'
+
+      - name: Check for backend file changes for Docker Compose builds
+        uses: dorny/paths-filter@v3.0.2
+        id: compose-changes
+        with:
+          filters: |
+            trackAndTrace:
+              - 'trackAndTrace/**'
+            compliant-reward-distribution:
+              - 'compliant-reward-distribution/**'
+
+  docker-build:
+    name: Building Docker Containers
+    # Require the diff job.
+    needs: changes
+    # Don't run on draft pull requests
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.docker-changes != '[]' && needs.changes.outputs.docker-changes != '' }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        image:
-          - {dir: euroe-demo, dockerfile: scripts/Dockerfile}
-          - {dir: ., dockerfile: gallery/Dockerfile}
-          - {dir: signMessage, dockerfile: Dockerfile}
-          - {dir: simpleAgeVerification, dockerfile: Dockerfile}
-          - {dir: ., dockerfile: sponsoredTransactions/Dockerfile}
-          - {dir: ., dockerfile: sponsoredTransactionsAuction/Dockerfile}
+        # JSON array contains all directories with docker images which have changed files
+        # e.g. ['euroe-demo', 'signMessage'] if both package folders contains changes
+        image: ${{ fromJSON(needs.changes.outputs.docker-changes) }}
 
     steps:
     - name: Checkout
@@ -32,20 +90,44 @@ jobs:
         submodules: recursive
 
     - name: Build image
-      working-directory: ${{ matrix.image.dir }}
-      run:
-        docker build -f ${{ matrix.image.dockerfile }} .
+      working-directory: ${{ env.DOCKER_DIR }}
+      run: |
+        echo "${{ matrix.image }} is the matrix image to build"
+  
+    - name: Set the path to the docker build directory to the dapp name for some apps.
+      if: ${{ contains(fromJson('["euroe-demo", "signMessage", "simpleAgeVerification"]'), matrix.image) }}
+      run: |
+        echo "DOCKER_DIR=./${{ matrix.image }}" >> $GITHUB_ENV
+
+    - name: Set the path to the dockerfile to the scripts subdirectory for euroe-demo.
+      if: ${{ contains(fromJson('["euroe-demo"]'), matrix.image) }}
+      run: |
+        echo "DOCKERFILE_DIR=./scripts" >> $GITHUB_ENV
+  
+    - name: Set the path to the dockerfile where it is the dapp name.
+      if: ${{ contains(fromJson('["gallery", "sponsoredTransactionsAuction", "sponsoredTransactions"]'), matrix.image) }}
+      run: |
+        echo "DOCKERFILE_DIR=./${{ matrix.image }}" >> $GITHUB_ENV
+
+    - name: Build image
+      working-directory: ${{ env.DOCKER_DIR }}
+      run: |
+        echo "DOCKER_DIR is ${DOCKER_DIR}"
+        echo "DOCKERFILE_DIR is ${DOCKERFILE_DIR}"
+        docker build -f ${{ env.DOCKERFILE_DIR}}/Dockerfile .
 
   compose-build:
-    name: Building with docker compose
+    name: Building dapps which use Docker Compose
+    # Require the diff job.
+    needs: changes
     # Don't run on draft pull requests
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        directories:
-          - trackAndTrace
-          - compliant-reward-distribution
+        # JSON array contains all directories with docker compose builds which have changed files
+        dapp: ${{ fromJSON(needs.changes.outputs.compose-changes) }}
 
     steps:
     - name: Checkout
@@ -53,13 +135,19 @@ jobs:
       with:
         submodules: recursive
 
+    - name: If building Track and Trace app, set environment variables.
+      if: ${{ matrix.dapp == 'trackAndTrace' }}
+      # Dummy values are set for the `trackAndTrace` run because `docker compose build`
+      # enforces the presence of environment variables during the build phase,
+      # even though these variables are only needed at runtime.
+      run: |
+        echo "TRACK_AND_TRACE_CONTRACT_ADDRESS=<8351,0>" >> $GITHUB_ENV
+        echo "TRACK_AND_TRACE_PRIVATE_KEY_FILE=./trackAndTrace/README.md" >> $GITHUB_ENV
+
     - name: Build with docker compose
-      working-directory: ${{ matrix.directories }}
-      env:
-        # Dummy values are set for the `trackAndTrace` run because `docker compose build`
-        # enforces the presence of environment variables during the build phase,
-        # even though these variables are only needed at runtime.
-        TRACK_AND_TRACE_CONTRACT_ADDRESS: "<8351,0>"
-        TRACK_AND_TRACE_PRIVATE_KEY_FILE: "./trackAndTrace/README.md"
-      run:
+      working-directory: ${{ matrix.dapp }}        
+      run: |
+        env | grep TRACK
+        pwd
         docker compose build
+

--- a/compliant-reward-distribution/docker-compose.yml
+++ b/compliant-reward-distribution/docker-compose.yml
@@ -4,6 +4,8 @@ version: '3.8'
 #  - `ADMIN_ACCOUNT`: An admin account that can read and write to the database.
 #  - `CONCORDIUM_NODE`: The gRPC interface of a node on the correct network. (Defaults to 'https://grpc.testnet.concordium.com')
 
+# TEMP: Changing file to trigger CI.
+
 services:
   postgres:
     image: postgres:latest

--- a/euroe-demo/scripts/Dockerfile
+++ b/euroe-demo/scripts/Dockerfile
@@ -1,3 +1,5 @@
+# TEMP: Changing file to trigger CI.
+
 ARG build_image="node:20-slim"
 FROM ${build_image} AS build
 WORKDIR /app

--- a/sponsoredTransactions/Dockerfile
+++ b/sponsoredTransactions/Dockerfile
@@ -1,6 +1,8 @@
 ARG node_base_image=node:20-slim
 ARG rust_base_image=rust:1.85
 
+# TEMP: Changing file to trigger CI.
+
 FROM ${node_base_image} AS frontend
 
 WORKDIR /app


### PR DESCRIPTION
## Purpose

Currently, every docker image is build in response to any pull request. This updates the Github Actions workflow to only trigger builds when non-markdown files are changed in the target directory.

## Changes

Add paths-filter action to generate a list of changed paths as step output: https://github.com/dorny/paths-filter 

Pass that output into the image build steps as a matrix to trigger only the relevant workflow.

Add conditional steps to set the docker file location and working directory depending on which build is triggered, as well as custom variables for track & trace dapp.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

I'm not sure if we track changes to CI in any changelog for this repo, please let me know if so.