### PR TITLE
feat(allowListManager): Support multiple tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ gallery/public
 
 # Key files exported from the Concordium browser wallet
 */**/*.export
+
+# Config file for allowListManagerFauced backend
+allowListManagerFaucet/backend/config/token-config.json

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following examples are available.
 
 - [testnet-faucet](./testnet-faucet/) implements the Concordium testnet faucet which requires the user to post on X (former Twitter) and complete a CAPTCHA task to claim testnet CCDs. The faucet allows claiming once within a specified timeframe.
 
-- [allowListManagerFaucet](./allowListManagerFaucet/) demonstrates a token allow list management system with EU nationality verification. Users prove their EU citizenship through Concordium ID, and upon successful verification, they are automatically added to a token's allow list and receive an airdrop. The example includes a React frontend, NestJS backend for blockchain operations, and the web3id-verifier-ts service which needs to run against devnet for credential proof verification.
+- [allowListManagerFaucet](./allowListManagerFaucet/) demonstrates a single or multi-token vending system (Faucet) for PLTs with ID Attribute verification. For PLTs with allow-lists, Users must prove something about themselves (e.g. EU residency) through Concordium ID, and upon successful verification, they are automatically added to a token's allow list and receive an airdrop. The example includes a React frontend, NestJS backend for blockchain operations, and depends on the web3id-verifier-ts service.
 
 - [nft-minting](./nft-minting/) demonstrates how to make a website that allows no-code minting with smart contracts on the Concordium blockchain.
 
@@ -42,7 +42,6 @@ The following examples are available.
 
 - [voting](./voting/) demonstrates how to integrate with smart contracts on the Concordium blockchain. You can create and customize your own voting smart contract via the front-end and deploy it to the Concordium chain. The front-end also provides pages to conduct the voting and display the voting results.
 
-- [eSealing](./eSealing/) demonstrates an example of how to integrate with smart contracts on the Concordium blockchain. This web app supports the following two flows with the browser wallet (or wallet connect): 
+- [eSealing](./eSealing/) demonstrates an example of how to integrate with smart contracts on the Concordium blockchain. This web app supports the following two flows with the browser wallet (or wallet connect):
   - Compute the file hash of a selected file => register its file hash in the smart contract
   - Compute the file hash of a selected file => retrieve the time-stamp and witness (sender_account) that registered the file hash
-

--- a/allowListManagerFaucet/README.md
+++ b/allowListManagerFaucet/README.md
@@ -1,15 +1,15 @@
 # Concordium Allow List dApp
 
-Complete token distribution system with EU nationality verification on Concordium, featuring single-transaction atomic operations.
+Complete token distribution system with ID proof based allow list management on Concordium, featuring single-transaction atomic operations.
 
 ## 🎯 Overview
 
-This dApp automatically distributes PLT tokens to users who prove EU nationality using zero-knowledge proofs. Using the latest Concordium SDK's `Token.sendOperations`, all operations execute in a single atomic transaction.
+This dApp automatically distributes PLT tokens to users, who for allow-list enabled tokens are asked for a prove about their ID (e.g. residency, date of birth in a range) using zero-knowledge proofs. Using the latest Concordium SDK's `Token.sendOperations`, all operations execute in a single atomic transaction.
 
 ## 🔄 How It Works
 
 1. **User connects** Concordium wallet
-2. **User proves** EU nationality (zero-knowledge proof)
+2. **User proves** Something from their Concordium ID (configurable zero-knowledge proof)
 3. **Backend executes single atomic transaction**:
    ```
    Token.sendOperations([
@@ -42,14 +42,14 @@ Frontend (React)          Backend (NestJS)              Concordium Blockchain
 ### Prerequisites
 - Node.js v18.18.0+
 - Concordium Browser Wallet (devnet version)
-- Governance wallet export with PLT minting permissions
+- Wallet export with PLT minting permissions for all tokens to be vended
 
 ### 1. Backend Setup
 ```bash
 cd backend
 npm install
 mkdir wallet
-# Place governance wallet export in wallet/
+# Place the wallet export in wallet/wallet.export
 # Configure your settings, create .env file
 
 Create .env file in backend root:
@@ -63,8 +63,9 @@ CONCORDIUM_USE_SSL=true
 # Token Configuration
 DEFAULT_TOKEN_ID=YOUR_TOKEN_ID
 DEFAULT_MINT_AMOUNT=100
+TOKEN_CONFIG_PATH=./config/token-config.json (optional, used to vend multiple PLTs)
 
-# Governance Wallet
+# Minting Wallet
 GOVERNANCE_WALLET_PATH=./wallet/wallet.export
 
 # Server Configuration
@@ -79,7 +80,7 @@ The frontend supports the following optional variables:
 
 TOKEN_ID - The token identifier to use for distribution, only reflects the text in the frontend
 BACKEND_URL - The backend API endpoint
-VERIFIER_URL (default: 'https://web3id-verifier.testnet.concordium.com') - The zero-knowledge proof verification service endpoint. If not set, the default verifier URL is used which runs the following back-end code: 
+VERIFIER_URL (default: 'https://web3id-verifier.testnet.concordium.com') - The zero-knowledge proof verification service endpoint. If not set, the default verifier URL is used which runs the following back-end code:
 https://github.com/Concordium/concordium-web3id/tree/main/services/web3id-verifier
 
 To configure these for local testing, you can modify the variables mentioned above in `AllowListDApp.tsx` or set them via `window.runtimeConfig`.
@@ -98,6 +99,42 @@ Open `http://localhost:5173` and connect your Concordium wallet.
 
 ### New Endpoints (Recommended)
 - `POST /token-distribution/distribute` - Start token distribution
+
+### Optional JSON Token Config
+
+If `TOKEN_CONFIG_PATH` is set, the backend loads token definitions from that JSON file.
+If it is not set, the backend keeps the existing single-token behavior using `DEFAULT_TOKEN_ID`
+and `DEFAULT_MINT_AMOUNT`.
+
+For Docker, the backend container mounts `./backend/config` to `/app/config`, so a value like
+`TOKEN_CONFIG_PATH=./config/token-config.json` resolves to `/app/config/token-config.json`.
+
+Example file: `backend/config/token-config.example.json`
+
+```json
+{
+  "$schema": "./tokens.schema.json",
+  "tokens": [
+    {
+      "id": "TestLists",
+      "amount": 100,
+      "hasAllowList": true
+    },
+    {
+      "id": "EUROe",
+      "amount": 50,
+      "hasAllowList": true
+    },
+    {
+      "id": "GatedAccess",
+      "amount": 0,
+      "hasAllowList": true
+    }
+  ]
+}
+```
+
+Setting `amount` to `0` enables **allow-list-only mode**: the user is verified and added to the token's allow list, but no PLTs are minted or transferred. This is useful for gating access without distributing tokens.
 - `GET /token-distribution/status/:id` - Check process status
 - `GET /token-distribution/allowlist/:user/:token?` - Check allowlist status
 - `GET /token-distribution/balance/:token/:user` - Get token balance
@@ -115,8 +152,8 @@ const combinedTx = await Token.sendOperations(
   [
     { addAllowList: { target: targetHolder } },
     { mint: { amount: tokenAmount } },
-    { transfer: { 
-      recipient: targetHolder, 
+    { transfer: {
+      recipient: targetHolder,
       amount: tokenAmount,
       memo: CborMemo.fromString(`Faucet distribution`)
     }}
@@ -127,7 +164,7 @@ const combinedTx = await Token.sendOperations(
 
 ## 🔐 Security
 
-- Governance wallet manages all token operations
+- Wallet manages all token operations
 - Zero-knowledge proofs protect user privacy
 - Atomic transactions prevent partial states
 - No intermediate failure points
@@ -142,22 +179,22 @@ backend/
 │   │   ├── concordium/        # Blockchain connection
 │   │   └── token-distribution/ # All token operations
 │   └── main.ts, app.module.ts, app.controller.ts
-   
+
 frontend/
 ├── src/
 │   ├── components/
 │   │   └── AllowListDApp.tsx  # Main UI component
 │   └── services/
 │       └── wallet-connection.ts
-|       |__ credential-provider-services.tsx  
+|       |__ credential-provider-services.tsx
 ```
 
 ## 🚨 Important Notes
 
-- **Governance wallet required**: Must be the token issuer
+- **Wallet required**: Must be able to mint, send (and add to allow-lists) for vended tokens
 - **Wallet security**: Never commit wallet files
 - **Environment files**: Create your own .env files
-- **Token configuration**: Update TOKEN_ID in both frontend and backend
+- **Token configuration**: Update TOKEN_ID and/or config file in backend
 
 ## 📝 License
 

--- a/allowListManagerFaucet/backend/config/token-config.example.json
+++ b/allowListManagerFaucet/backend/config/token-config.example.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "./tokens.schema.json",
+  "tokens": [
+    {
+      "id": "nonEuroPLT",
+      "amount": 100,
+      "hasAllowList": true,
+      "proof": {
+        "description": "Non-EU residency",
+        "statements": [
+          {
+            "type": "AttributeNotInSet",
+            "attributeTag": "countryOfResidence",
+            "set": [
+              "AT",
+              "BE",
+              "BG",
+              "CY",
+              "CZ",
+              "DE",
+              "DK",
+              "EE",
+              "ES",
+              "FI",
+              "FR",
+              "GR",
+              "HR",
+              "HU",
+              "IE",
+              "IT",
+              "LT",
+              "LU",
+              "LV",
+              "MT",
+              "NL",
+              "PL",
+              "PT",
+              "RO",
+              "SE",
+              "SI",
+              "SK"
+            ]
+          }
+        ],
+        "issuers": [
+          0
+        ]
+      }
+    },
+    {
+      "id": "EUROe",
+      "amount": 50,
+      "hasAllowList": true,
+      "proof": {
+        "description": "EU residency",
+        "statements": [
+          {
+            "type": "AttributeInSet",
+            "attributeTag": "countryOfResidence",
+            "set": [
+              "AT",
+              "BE",
+              "BG",
+              "CY",
+              "CZ",
+              "DE",
+              "DK",
+              "EE",
+              "ES",
+              "FI",
+              "FR",
+              "GR",
+              "HR",
+              "HU",
+              "IE",
+              "IT",
+              "LT",
+              "LU",
+              "LV",
+              "MT",
+              "NL",
+              "PL",
+              "PT",
+              "RO",
+              "SE",
+              "SI",
+              "SK"
+            ]
+          }
+        ],
+        "issuers": [
+          0
+        ]
+      }
+    },
+    {
+      "id": "FreeToken",
+      "amount": 25,
+      "hasAllowList": false
+    }
+  ]
+}

--- a/allowListManagerFaucet/backend/config/tokens.schema.json
+++ b/allowListManagerFaucet/backend/config/tokens.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Concordium/concordium-dapp-examples/allowListManagerFaucet/tokens-config",
+  "title": "PLT Token Distribution Config",
+  "description": "Token configuration for the allowListManagerFaucet distribution service.",
+  "type": "object",
+  "required": [
+    "tokens"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "tokens": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Token ID as it appears on-chain."
+          },
+          "amount": {
+            "type": "number",
+            "minimum": 0,
+            "description": "PLTs to mint and transfer per distribution. Set to 0 for allow-list-only mode (adds the user to the allow list without minting or transferring tokens). Defaults to the DEFAULT_MINT_AMOUNT env var if not provided."
+          },
+          "hasAllowList": {
+            "type": "boolean",
+            "description": "Whether this token uses an allow list. When true the user is added to the allow list before receiving tokens. Defaults to true."
+          },
+          "proof": {
+            "$ref": "#/$defs/proofConfig",
+            "description": "ZK proof / verifiable-presentation requirements. Only meaningful when hasAllowList is true. If omitted on an allow-list token the frontend falls back to the built-in EU residency proof."
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "proofConfig": {
+      "type": "object",
+      "required": [
+        "description",
+        "statements",
+        "issuers"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable label shown in the UI, e.g. \"EU residency\" or \"Age 18+\"."
+        },
+        "statements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/proofStatement"
+          }
+        },
+        "issuers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Concordium identity provider ID."
+          },
+          "description": "Accepted Concordium identity provider IDs."
+        }
+      }
+    },
+    "proofStatement": {
+      "type": "object",
+      "required": [
+        "type",
+        "attributeTag"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AttributeInSet",
+            "AttributeNotInSet",
+            "AttributeInRange"
+          ],
+          "description": "Statement type."
+        },
+        "attributeTag": {
+          "type": "string",
+          "description": "Identity attribute to check, e.g. \"nationality\", \"countryOfResidence\", \"dob\"."
+        },
+        "set": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "Required for AttributeInSet and AttributeNotInSet. List of accepted (or rejected) attribute values."
+        },
+        "lower": {
+          "type": "string",
+          "description": "Required for AttributeInRange. Inclusive lower bound."
+        },
+        "upper": {
+          "type": "string",
+          "description": "Required for AttributeInRange. Exclusive upper bound."
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "enum": [
+              "AttributeInSet",
+              "AttributeNotInSet"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "set"
+        ]
+      },
+      "else": {
+        "if": {
+          "properties": {
+            "type": {
+              "const": "AttributeInRange"
+            }
+          }
+        },
+        "then": {
+          "required": [
+            "lower",
+            "upper"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/allowListManagerFaucet/backend/package-lock.json
+++ b/allowListManagerFaucet/backend/package-lock.json
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@concordium/web-sdk": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-10.0.1.tgz",
-      "integrity": "sha512-yQ3KD4xHBLTtDBITnvy3KHlYGsrPclJeK5tWGTMa7lYQ+etGLrEy0jqM64Y2moDnJ5qlQJqWuw+Lf68ALhyDwg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-10.0.2.tgz",
+      "integrity": "sha512-0RvjeO4McnoKtlv6/8JarIAm1rZz2NmOZp7P39Hs2onvTHu4A2VeCV3qQnD3YhKn5++qlKGnaXxSs+grYfciQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@concordium/rust-bindings": "^3.3.0",
@@ -167,24 +167,30 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.2.tgz",
-      "integrity": "sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "16.4.7",
-        "dotenv-expand": "12.0.1",
-        "lodash": "4.17.21"
+        "dotenv": "17.4.1",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.18.1"
       },
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/config/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/core": {
-      "version": "10.4.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.17.tgz",
-      "integrity": "sha512-Tk4J5aS082NUYrsJEDLvGdU+kRnHAMdOvsA4j62fP5THO6fN6vqv6jWHfydhCiPGUCJWLT6m+mNIhETMhMAs+Q==",
+      "version": "10.4.22",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.22.tgz",
+      "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -240,15 +246,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.4.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.17.tgz",
-      "integrity": "sha512-ovn4Wxney3QGBrqNPv0QLcCuH5QoAi6pb/GNWAz6B/NmBjZbs9/zl4a2beGDA2SaYre9w43YbfmHTm17PneP9w==",
+      "version": "10.4.22",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
+      "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
       "dependencies": {
-        "body-parser": "1.20.3",
+        "body-parser": "1.20.4",
         "cors": "2.8.5",
-        "express": "4.21.2",
-        "multer": "1.4.4-lts.1",
+        "express": "4.22.1",
+        "multer": "2.0.2",
         "tslib": "2.8.1"
       },
       "funding": {
@@ -383,25 +389,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -411,9 +416,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -429,9 +434,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@scure/base": {
@@ -559,19 +564,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -659,23 +651,23 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -696,6 +688,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -932,17 +935,17 @@
       "license": "MIT"
     },
     "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
-        "node >= 0.8"
+        "node >= 6.0"
       ],
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
       }
     },
@@ -974,24 +977,18 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -1044,9 +1041,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1056,13 +1053,25 @@
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
-      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "dotenv": "^16.4.5"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -1124,9 +1133,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1160,39 +1169,39 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -1221,9 +1230,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -1270,17 +1279,17 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.2",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -1447,9 +1456,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1459,19 +1468,23 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
@@ -1582,12 +1595,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
     },
     "node_modules/iso-3166-1": {
       "version": "2.1.1",
@@ -1724,6 +1731,19 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1752,22 +1772,21 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "1.4.4-lts.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.4-lts.1.tgz",
-      "integrity": "sha512-WeSGziVj6+Z2/MwQo3GvqzgR+9Uc+qt8SwHKh3gvNPiISKfsMfG4SvCOFYlxxgkXt7yIV2i1yczehm0EOKIxIg==",
-      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
         "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/negotiator": {
@@ -1828,17 +1847,6 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1847,19 +1855,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/nodemon/node_modules/supports-color": {
@@ -1946,31 +1941,38 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1997,12 +1999,12 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -2021,40 +2023,33 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -2067,19 +2062,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/reflect-metadata": {
@@ -2146,24 +2128,24 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -2184,25 +2166,16 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -2215,14 +2188,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2234,13 +2207,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2300,9 +2273,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2317,19 +2290,13 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2561,9 +2528,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
-      "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/allowListManagerFaucet/backend/package.json
+++ b/allowListManagerFaucet/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allowlist-backend",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "NestJS backend for Concordium Allow List dApp",
   "author": "",
   "private": true,

--- a/allowListManagerFaucet/backend/src/modules/token-distribution/dto/add-to-allow-list.dto.ts
+++ b/allowListManagerFaucet/backend/src/modules/token-distribution/dto/add-to-allow-list.dto.ts
@@ -11,7 +11,7 @@ export class AddToAllowListDto {
   userAccount: string
 
   @ApiProperty({
-    description: 'Optional token ID to manage (defaults to configured PLT)',
+    description: 'Optional token ID to manage (defaults to first configured PLT)',
     required: false
   })
   @IsString()

--- a/allowListManagerFaucet/backend/src/modules/token-distribution/token-distribution.controller.ts
+++ b/allowListManagerFaucet/backend/src/modules/token-distribution/token-distribution.controller.ts
@@ -24,8 +24,15 @@ export class TokenDistributionController {
     private readonly processTrackingService: ProcessTrackingService,
   ) {}
 
+  @Get('tokens')
+  @ApiOperation({ summary: 'List configured PLT tokens available for distribution' })
+  @ApiResponse({ status: 200, description: 'Array of configured tokens with their mint amounts' })
+  getConfiguredTokens() {
+    return this.tokenDistributionService.getConfiguredTokens()
+  }
+
   @Post('distribute')
-  @ApiOperation({ 
+  @ApiOperation({
     summary: 'Start token distribution process', 
     description: 'Adds user to allowlist, mints tokens, and transfers them in a single atomic transaction' 
   })

--- a/allowListManagerFaucet/backend/src/modules/token-distribution/token-distribution.service.ts
+++ b/allowListManagerFaucet/backend/src/modules/token-distribution/token-distribution.service.ts
@@ -138,8 +138,9 @@ export class TokenDistributionService implements OnModuleInit {
    */
   async startTokenDistribution(dto: AddToAllowListDto): Promise<string> {
     const processId = uuidv4()
-    const tokenId = dto.tokenId || this.tokenConfigs[0].id
-    const tokenConfig = this.tokenConfigs.find(c => c.id === tokenId) ?? this.tokenConfigs[0]
+    const bail = (msg: string) => throw new Error(msg)
+    const tokenId = dto.tokenId ?? this.tokenConfigs[0].id
+    const tokenConfig = this.tokenConfigs.find(c => c.id === tokenId) ?? bail(`Could not find configured token with ID ${tokenId}.`)
 
     // Eligible only if the account has no token entry at all (never held this token).
     // A null balance means no entry; any string value (including '0') means the account

--- a/allowListManagerFaucet/backend/src/modules/token-distribution/token-distribution.service.ts
+++ b/allowListManagerFaucet/backend/src/modules/token-distribution/token-distribution.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { readFileSync } from 'node:fs'
 import { ConcordiumService } from '../concordium/concordium.service.js'
 import { ProcessTrackingService } from './process-tracking.service.js'
 import { TokenId, TokenAmount, Token, TokenHolder, CborMemo, Cbor } from '@concordium/web-sdk/plt'
@@ -12,39 +13,149 @@ import {
   TransactionEventTag
 } from '@concordium/web-sdk'
 
+export interface ProofStatementConfig {
+  type: 'AttributeInSet' | 'AttributeNotInSet' | 'AttributeInRange'
+  attributeTag: string
+  set?: string[]
+  lower?: string
+  upper?: string
+}
+
+export interface ProofConfig {
+  description: string
+  statements: ProofStatementConfig[]
+  issuers: number[]
+}
+
+export interface TokenConfig {
+  id: string
+  amount: number
+  hasAllowList: boolean
+  proof?: ProofConfig
+  iconUrl?: string
+  description?: string
+}
+
+interface TokenConfigFileEntry {
+  id: string
+  amount?: number
+  hasAllowList?: boolean
+  proof?: ProofConfig
+}
+
+interface TokenConfigFile {
+  tokens: TokenConfigFileEntry[]
+}
+
 @Injectable()
-export class TokenDistributionService {
+export class TokenDistributionService implements OnModuleInit {
   private readonly logger = new Logger(TokenDistributionService.name)
-  private readonly defaultTokenId: string
-  private readonly defaultMintAmount: number
+  private readonly tokenConfigs: TokenConfig[]
 
   constructor(
     private readonly concordiumService: ConcordiumService,
     private readonly processTrackingService: ProcessTrackingService,
     private readonly configService: ConfigService,
   ) {
-    this.defaultTokenId = this.configService.get('DEFAULT_TOKEN_ID', 'TestLists')
-    this.defaultMintAmount = parseInt(this.configService.get('DEFAULT_MINT_AMOUNT', '100'))
-    this.logger.log(`Initialized with default token: ${this.defaultTokenId}, amount: ${this.defaultMintAmount}`)
+    this.tokenConfigs = this.loadTokenConfigs()
+
+    this.logger.log(`Initialized with token configs: ${JSON.stringify(this.tokenConfigs)}`)
+  }
+
+  async onModuleInit() {
+    await this.enrichTokensWithIcons()
+  }
+
+  private async enrichTokensWithIcons() {
+    const client = this.concordiumService.getClient()
+    for (const tokenConfig of this.tokenConfigs) {
+      try {
+        const token = await Token.fromId(client, TokenId.fromString(tokenConfig.id))
+        const metadataUrl = token.moduleState.metadata.url
+        const response = await fetch(metadataUrl)
+        if (response.ok) {
+          const metadata = await response.json() as { thumbnail?: { url: string }; display?: { url: string }; description?: string }
+          tokenConfig.iconUrl = metadata.thumbnail?.url ?? metadata.display?.url
+          tokenConfig.description = metadata.description
+          this.logger.log(`Loaded metadata for ${tokenConfig.id}: icon=${tokenConfig.iconUrl}, description=${tokenConfig.description}`)
+        }
+      } catch (error) {
+        this.logger.warn(`Could not load icon for token ${tokenConfig.id}: ${error.message}`)
+      }
+    }
+  }
+
+  private loadTokenConfigs(): TokenConfig[] {
+    const tokenConfigPath = this.configService.get<string>('TOKEN_CONFIG_PATH', '')
+
+    if (tokenConfigPath) {
+      try {
+        const configFile = readFileSync(tokenConfigPath, 'utf8')
+        const parsed = JSON.parse(configFile) as TokenConfigFile
+
+        if (!Array.isArray(parsed.tokens) || parsed.tokens.length === 0) {
+          throw new Error('token config file must have a non-empty "tokens" array')
+        }
+
+        return parsed.tokens.map((entry, index) => {
+          if (!entry?.id) {
+            throw new Error(`token config entry at index ${index} is missing id`)
+          }
+
+          return {
+            id: entry.id,
+            amount: typeof entry.amount === 'number' ? entry.amount : this.getDefaultMintAmount(),
+            hasAllowList: entry.hasAllowList ?? true,
+            proof: entry.proof,
+          }
+        })
+      } catch (error) {
+        this.logger.error(`Failed to load token config from ${tokenConfigPath}: ${error.message}`)
+        throw new Error(`Token config initialization failed: ${error.message}`)
+      }
+    }
+
+    return [
+      {
+        id: this.configService.get('DEFAULT_TOKEN_ID', 'TestLists'),
+        amount: this.getDefaultMintAmount(),
+        hasAllowList: true,
+      },
+    ]
+  }
+
+  private getDefaultMintAmount(): number {
+    return parseInt(this.configService.get('DEFAULT_MINT_AMOUNT', '100'))
+  }
+
+  getConfiguredTokens(): TokenConfig[] {
+    return this.tokenConfigs
   }
 
   /**
-   * Starts the token distribution process for a verified user
-   * Executes all operations in a single atomic transaction
+   * Starts the token distribution process for a verified user.
+   * Resolves the token ID from the DTO (or first configured token) and its configured mint amount.
    */
   async startTokenDistribution(dto: AddToAllowListDto): Promise<string> {
     const processId = uuidv4()
-    const tokenId = dto.tokenId || this.defaultTokenId
+    const tokenId = dto.tokenId || this.tokenConfigs[0].id
+    const tokenConfig = this.tokenConfigs.find(c => c.id === tokenId) ?? this.tokenConfigs[0]
 
-    this.logger.log(`Starting token distribution process ${processId} for user ${dto.userAccount}`)
+    // Eligible only if the account has no token entry at all (never held this token).
+    // A null balance means no entry; any string value (including '0') means the account
+    // has held the token before, even if the balance is now zero.
+    const currentBalance = await this.getTokenBalance(tokenConfig.id, dto.userAccount)
+    if (currentBalance !== null) {
+      throw new Error(`Account ${dto.userAccount} has previously held token ${tokenConfig.id} and is not eligible for distribution`)
+    }
 
-    // Initialize process tracking with single step
+    this.logger.log(`Starting token distribution process ${processId} for user ${dto.userAccount} on token ${tokenId} (allowList: ${tokenConfig.hasAllowList})`)
+
     this.processTrackingService.initializeProcess(processId, [
       { step: 'Execute Token Distribution', status: 'pending', progress: 0 },
     ])
 
-    // Start async process
-    this.executeTokenDistribution(processId, dto, tokenId).catch(error => {
+    this.executeTokenDistribution(processId, dto, tokenConfig).catch(error => {
       this.logger.error(`Process ${processId} failed: ${error.message}`)
       this.processTrackingService.markProcessFailed(processId, error.message)
     })
@@ -52,26 +163,27 @@ export class TokenDistributionService {
     return processId
   }
 
-  private async executeTokenDistribution(processId: string, dto: AddToAllowListDto, tokenIdStr: string) {
+  private async executeTokenDistribution(processId: string, dto: AddToAllowListDto, tokenConfig: TokenConfig) {
     try {
-      // Update status to processing
       this.processTrackingService.updateStep(processId, 0, 'processing')
 
-      // Execute the combined transaction
       const txHash = await this.executeCombinedTokenOperation(
         dto.userAccount,
-        tokenIdStr,
-        this.defaultMintAmount
+        tokenConfig.id,
+        tokenConfig.amount,
+        tokenConfig.hasAllowList,
       )
 
-      // Update status to completed
       this.processTrackingService.updateStep(processId, 0, 'completed', txHash)
 
-      // Mark process as completed
+      const operations = [
+        ...(tokenConfig.hasAllowList ? ['addToAllowList'] : []),
+        ...(tokenConfig.amount > 0 ? ['mint', 'transfer'] : []),
+      ]
       this.processTrackingService.markProcessCompleted(processId, {
         transactionHash: txHash,
-        operations: ['addToAllowList', 'mint', 'transfer'],
-        tokensTransferred: this.defaultMintAmount,
+        operations,
+        tokensTransferred: tokenConfig.amount,
       })
 
       this.logger.log(`Process ${processId} completed successfully with transaction: ${txHash}`)
@@ -91,29 +203,24 @@ export class TokenDistributionService {
   private async executeCombinedTokenOperation(
     userAccount: string,
     tokenIdStr: string,
-    amount: number
+    amount: number,
+    hasAllowList: boolean,
   ): Promise<string> {
     try {
       const client = this.concordiumService.getClient()
       const userAddress = this.concordiumService.parseAccountAddress(userAccount)
       const { sender, signer } = this.concordiumService.loadGovernanceWallet()
 
-      this.logger.log(`Executing combined operation for ${userAccount} on token ${tokenIdStr}`)
+      this.logger.log(`Executing combined operation for ${userAccount} on token ${tokenIdStr} (allowList: ${hasAllowList})`)
 
-      // Create token instance and prepare parameters
       const tokenId = TokenId.fromString(tokenIdStr)
       const token = await Token.fromId(client, tokenId)
       const tokenAmount = TokenAmount.fromDecimal(amount, token.info.state.decimals)
       const targetHolder = TokenHolder.fromAccountAddress(userAddress)
 
-      // Execute all operations in a single transaction
-      this.logger.log(`Sending combined transaction: add to allowlist + mint ${amount} + transfer to ${userAccount}`)
-
-      const combinedTx = await Token.sendOperations(
-        token,
-        sender,
-        [
-          { addAllowList: { target: targetHolder } },
+      const ops = [
+        ...(hasAllowList ? [{ addAllowList: { target: targetHolder } }] : []),
+        ...(amount > 0 ? [
           { mint: { amount: tokenAmount } },
           {
             transfer: {
@@ -122,9 +229,12 @@ export class TokenDistributionService {
               memo: CborMemo.fromString(`Faucet distribution to ${userAccount}`)
             }
           }
-        ],
-        signer
-      )
+        ] : []),
+      ]
+
+      this.logger.log(`Sending transaction: ${hasAllowList ? 'addAllowList + ' : ''}mint ${amount} + transfer to ${userAccount}`)
+
+      const combinedTx = await Token.sendOperations(token, sender, ops, signer)
 
       this.logger.log(`Combined transaction submitted: ${combinedTx}`)
 
@@ -169,7 +279,7 @@ export class TokenDistributionService {
   async isUserOnAllowList(userAccount: string, tokenId?: string): Promise<boolean> {
     try {
       const userAddress = this.concordiumService.parseAccountAddress(userAccount)
-      const checkTokenId = tokenId || this.defaultTokenId
+      const checkTokenId = tokenId || this.tokenConfigs[0].id
       const client = this.concordiumService.getClient()
 
       this.logger.log(`Checking allowlist status for ${userAccount} on token ${checkTokenId}`)
@@ -225,9 +335,11 @@ export class TokenDistributionService {
   }
 
   /**
-   * Gets token balance for a user
+   * Gets token balance for a user.
+   * Returns null when the account has no entry for this token (never held it) — the caller
+   * can use this to distinguish "never held" (eligible) from "held but spent" (ineligible).
    */
-  async getTokenBalance(tokenId: string, accountAddress: string): Promise<string> {
+  async getTokenBalance(tokenId: string, accountAddress: string): Promise<string | null> {
     try {
       const userAddress = this.concordiumService.parseAccountAddress(accountAddress)
       const client = this.concordiumService.getClient()
@@ -240,8 +352,8 @@ export class TokenDistributionService {
       const tokenInfo = tokenAccountInfo.find(balance => balance.id.value === tokenId)
 
       if (!tokenInfo) {
-        this.logger.log(`Token ${tokenId} not found in account ${accountAddress} - balance is 0`)
-        return "0"
+        this.logger.log(`Token ${tokenId} not found in account ${accountAddress} - never held`)
+        return null
       }
 
       const balance = tokenInfo.state.balance.toString()

--- a/allowListManagerFaucet/docker-compose.yml
+++ b/allowListManagerFaucet/docker-compose.yml
@@ -1,20 +1,24 @@
 services:
   backend:
-    build: 
+    build:
       context: ./backend
     ports:
       - "3001:3001"
+    volumes:
+      - ./backend/config:/app/config:ro
     environment:
       - CONCORDIUM_GRPC_HOST=${CONCORDIUM_GRPC_HOST}
       - CONCORDIUM_GRPC_PORT=${CONCORDIUM_GRPC_PORT}
       - DEFAULT_TOKEN_ID=${DEFAULT_TOKEN_ID}
+      - DEFAULT_MINT_AMOUNT=${DEFAULT_MINT_AMOUNT:-100}
+      - TOKEN_CONFIG_PATH=${TOKEN_CONFIG_PATH:-}
     depends_on:
       - web3id-verifier
     networks:
       - allowlist-network
 
   frontend:
-    build: 
+    build:
       context: ./frontend
       args:
         TOKEN_ID: ${DEFAULT_TOKEN_ID}

--- a/allowListManagerFaucet/frontend/build-and-serve.sh
+++ b/allowListManagerFaucet/frontend/build-and-serve.sh
@@ -12,12 +12,10 @@ else
 fi
 
 echo "Injecting runtime environment variables..."
-echo "TOKEN_ID: ${TOKEN_ID:-EUDemo}"
 echo "BACKEND_URL: ${BACKEND_URL:-http://localhost:3001}"
 echo "VERIFIER_URL: ${VERIFIER_URL:-http://localhost:8080}"
 
 # Replace placeholders in index.html with actual environment variable values
-sed -i "s|__TOKEN_ID__|${TOKEN_ID:-EUDemo}|g" dist/index.html
 sed -i "s|__BACKEND_URL__|${BACKEND_URL:-http://localhost:3001}|g" dist/index.html
 sed -i "s|__VERIFIER_URL__|${VERIFIER_URL:-http://localhost:8080}|g" dist/index.html
 

--- a/allowListManagerFaucet/frontend/index.html
+++ b/allowListManagerFaucet/frontend/index.html
@@ -10,7 +10,6 @@
     <!-- Runtime configuration - will be replaced by deployment script -->
     <script>
       window.runtimeConfig = {
-        TOKEN_ID: "__TOKEN_ID__",
         BACKEND_URL: "__BACKEND_URL__",
         VERIFIER_URL: "__VERIFIER_URL__"
       };

--- a/allowListManagerFaucet/frontend/package.json
+++ b/allowListManagerFaucet/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "allowlist-dapp-mvp",
     "license": "Apache-2.0",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "dependencies": {
         "@concordium/react-components": "^0.6.1",
         "@concordium/wallet-connectors": "^0.6.1",

--- a/allowListManagerFaucet/frontend/src/components/AllowListDApp.tsx
+++ b/allowListManagerFaucet/frontend/src/components/AllowListDApp.tsx
@@ -16,18 +16,65 @@ import { BROWSER_WALLET, WALLET_CONNECT } from '../../constants';
 import { Buffer } from 'buffer';
 
 declare global {
-  interface Window {
-    runtimeConfig: {
-      TOKEN_ID: string;
-      BACKEND_URL: string;
-      VERIFIER_URL: string;
-    };
-  }
+    interface Window {
+        runtimeConfig: {
+            BACKEND_URL: string;
+            VERIFIER_URL: string;
+        };
+        concordium?: {
+            requestAccounts(): Promise<string[]>;
+        };
+    }
 }
 
-const TOKEN_ID = window.runtimeConfig?.TOKEN_ID || 'EUDemo';
+interface ProofStatementConfig {
+    type: 'AttributeInSet' | 'AttributeNotInSet' | 'AttributeInRange';
+    attributeTag: string;
+    set?: string[];
+    lower?: string;
+    upper?: string;
+}
+
+interface ProofConfig {
+    description: string;
+    statements: ProofStatementConfig[];
+    issuers: number[];
+}
+
+interface TokenConfig {
+    id: string;
+    amount: number;
+    hasAllowList: boolean;
+    proof?: ProofConfig;
+    iconUrl?: string;
+    description?: string;
+}
+
 const BACKEND_URL = window.runtimeConfig?.BACKEND_URL || 'http://localhost:3001';
 const VERIFIER_URL = window.runtimeConfig?.VERIFIER_URL || 'https://web3id-verifier.testnet.concordium.com';
+
+const EU_COUNTRY_CODES = ["AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR", "HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT", "NL", "PL", "PT", "RO", "SE", "SI", "SK"];
+
+const DEFAULT_EU_PROOF: ProofConfig = {
+    description: 'EU nationality',
+    statements: [{ type: 'AttributeInSet', attributeTag: 'countryOfResidence', set: EU_COUNTRY_CODES }],
+    issuers: [0],
+};
+
+function buildCredentialStatements(proof: ProofConfig): CredentialStatements {
+    const statements: AtomicStatementV2[] = proof.statements.map(s => {
+        switch (s.type) {
+            case 'AttributeInSet':
+                return { type: StatementTypes.AttributeInSet, attributeTag: s.attributeTag, set: s.set! };
+            case 'AttributeNotInSet':
+                return { type: StatementTypes.AttributeNotInSet, attributeTag: s.attributeTag, set: s.set! };
+            case 'AttributeInRange':
+                return { type: StatementTypes.AttributeInRange, attributeTag: s.attributeTag, lower: s.lower!, upper: s.upper! };
+        }
+    });
+    return [{ statement: statements, idQualifier: { type: 'cred' as const, issuers: proof.issuers } } as CredentialStatement];
+}
+
 
 export default function AllowListDApp(props: WalletConnectionProps) {
 
@@ -39,67 +86,104 @@ export default function AllowListDApp(props: WalletConnectionProps) {
         props.activeConnector,
         setConnection
     );
+
+    // Process / proof state
     const [proofStatus, setProofStatus] = useState<string>('');
     const [isLoading, setIsLoading] = useState(false);
     const [message, setMessage] = useState<string>('');
     const [transactionHash, setTransactionHash] = useState<string>('');
     const [showProofDetails, setShowProofDetails] = useState(false);
     const [currentProof, setCurrentProof] = useState<string | null>(null);
-    const [tokenBalance, setTokenBalance] = useState<string>('');
-    const [balanceLoading, setBalanceLoading] = useState(false);
-    const [isOnAllowList, setIsOnAllowList] = useState<boolean | null>(null);
-    const [allowListChecking, setAllowListChecking] = useState(false);
     const [intentedConnectorType, setIntentedConnectorType] = useState<typeof BROWSER_WALLET | typeof WALLET_CONNECT | null>(null);
-    
-    useEffect(() => {
-        if (account) {
-            fetchTokenBalance(account);
-            checkAllowListStatus(account);
-        } else {
-            setTokenBalance('');
-            setIsOnAllowList(null);
-        }
-    }, [account]);
-    
-    const fetchTokenBalance = async (accountAddress: string) => {
-        if (!accountAddress) return;
 
-        setBalanceLoading(true);
-        try {
-            const response = await fetch(`${BACKEND_URL}/token-distribution/balance/${TOKEN_ID}/${accountAddress}`);
-            if (response.ok) {
-                const balanceData = await response.json();
-                setTokenBalance(balanceData.balance);
-            } else {
-                console.error('Failed to fetch balance:', response.statusText);
-                setTokenBalance('Error');
-            }
-        } catch (error) {
-            console.error('Error fetching balance:', error);
-            setTokenBalance('Error');
-        } finally {
-            setBalanceLoading(false);
-        }
+    // Token config
+    const [configuredTokens, setConfiguredTokens] = useState<TokenConfig[]>([]);
+    const [selectedTokenId, setSelectedTokenId] = useState<string>('');
+
+    // Per-token balances — eligibility is derived directly from these:
+    // undefined       → not yet fetched (unknown eligibility)
+    // null            → no token entry on the account (never held) → eligible
+    // '0' or any str → entry exists (held before, even if spent) → ineligible
+    const [tokenBalances, setTokenBalances] = useState<Record<string, string | null>>({});
+    const [balancesLoading, setBalancesLoading] = useState(false);
+
+    const isMultiToken = configuredTokens.length > 1;
+    const selectedToken = configuredTokens.find(t => t.id === selectedTokenId) ?? null;
+
+    // Eligibility is derived purely from whether the account has a token entry:
+    // undefined → still loading (unknown), null → no entry (never held) → eligible, string → entry exists → ineligible
+    const getTokenEligibility = (token: TokenConfig): boolean | null => {
+        const balance = tokenBalances[token.id];
+        if (balance === undefined) return null;
+        return balance === null;
     };
 
-    const checkAllowListStatus = async (accountAddress: string) => {
-        if (!accountAddress) return;
+    // Load token list from backend; fall back to runtimeConfig values
+    useEffect(() => {
+        fetch(`${BACKEND_URL}/token-distribution/tokens`)
+            .then(r => r.ok ? r.json() : Promise.reject())
+            .then((tokens: TokenConfig[]) => {
+                setConfiguredTokens(tokens);
+                setSelectedTokenId(tokens[0]?.id ?? '');
+            })
+            .catch(() => {
+                setConfiguredTokens([]);
+            });
+    }, []);
 
-        setAllowListChecking(true);
-        try {
-            const response = await fetch(`${BACKEND_URL}/token-distribution/allowlist/${accountAddress}/${TOKEN_ID}`);
-            if (response.ok) {
-                const statusData = await response.json();
-                setIsOnAllowList(statusData.isOnAllowList);
-            } else {
-                console.error('Failed to check allow list status:', response.statusText);
-                setIsOnAllowList(null);
-            }
-        } catch (error) {
-            console.error('Error checking allow list status:', error);
-            setIsOnAllowList(null);
-        } finally {
-            setAllowListChecking(false);
+    // Clear status when the selected token changes.
+    useEffect(() => {
+        setProofStatus('');
+        setMessage('');
+        setTransactionHash('');
+        setCurrentProof(null);
+        setShowProofDetails(false);
+    }, [selectedTokenId]);
+
+
+    // Clear status and in-progress state when the account changes.
+    useEffect(() => {
+        setProofStatus('');
+        setMessage('');
+        setTransactionHash('');
+        setCurrentProof(null);
+        setShowProofDetails(false);
+        setIsLoading(false);
+    }, [account]);
+
+    // When account or token list changes, fetch balances for all tokens.
+    // Eligibility is derived from balances, so this is the only fetch needed.
+    useEffect(() => {
+        if (account && configuredTokens.length > 0) {
+            fetchAllBalances(account, configuredTokens);
+        } else if (!account) {
+            setTokenBalances({});
+        }
+    }, [account, configuredTokens]);
+
+    const fetchAllBalances = async (accountAddress: string, tokens: TokenConfig[]) => {
+        setBalancesLoading(true);
+        const results = await Promise.all(tokens.map(async (token) => {
+            try {
+                const r = await fetch(`${BACKEND_URL}/token-distribution/balance/${token.id}/${accountAddress}`);
+                if (r.ok) {
+                    const data = await r.json();
+                    // null from backend = no token entry = never held
+                    return [token.id, data.balance] as [string, string | null];
+                }
+            } catch { /* ignore */ }
+            // On error, treat as null (never held) so the user can attempt to claim;
+            // the backend will enforce the rule authoritatively.
+            return [token.id, null] as [string, null];
+        }));
+        const balances = Object.fromEntries(results) as Record<string, string | null>;
+        setTokenBalances(balances);
+        setBalancesLoading(false);
+
+        // Auto-select first eligible token (null = no entry = eligible)
+        if (balances[selectedTokenId] !== null) {
+            const firstEligible = tokens.find(t => balances[t.id] === null);
+            if (firstEligible) setSelectedTokenId(firstEligible.id);
         }
     };
 
@@ -109,47 +193,32 @@ export default function AllowListDApp(props: WalletConnectionProps) {
             return;
         }
 
+        // Tokens without an allow list skip the proof step entirely
+        if (!effectiveProof) {
+            await startTokenDistribution();
+            return;
+        }
+
         setIsLoading(true);
-        setProofStatus('Requesting EU nationality proof...');
+        setProofStatus(`Requesting ${effectiveProof.description} proof...`);
         setMessage('');
         setTransactionHash('');
 
         try {
-            // Create a statement to check if nationality is in the EU countries
-            const euCountryCodes = ["AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR", "HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT", "NL", "PL", "PT", "RO", "SE", "SI", "SK"];
+            const credentialStatements = buildCredentialStatements(effectiveProof);
 
-            const nationalityStatement: AtomicStatementV2 = {
-                type: StatementTypes.AttributeInSet,
-                attributeTag: 'nationality',
-                set: euCountryCodes
-            };
-
-            const credentialStatements: CredentialStatements = [{
-                statement: [nationalityStatement],
-                idQualifier: {
-                    type: 'cred' as const, // Use 'cred' for identity provider
-                    issuers: [0] // Identity Provider 0 on testnet/devnet
-                }
-            } as CredentialStatement];
-
-            // Generate challenge
             const challengeBuffer = new Uint8Array(32);
             crypto.getRandomValues(challengeBuffer);
             const challenge = Buffer.from(challengeBuffer).toString('hex') as HexString;
 
-            // Request verifiable presentation from wallet
             let proof: VerifiablePresentation;
             try {
                 proof = await connection.requestVerifiablePresentation(challenge, credentialStatements);
                 setCurrentProof(proof.toString());
             } catch (err: any) {
-                if (err instanceof Error) {
-                    setProofStatus(`Could not get proof: ${err.message}`);
-                    setMessage('Failed to get proof from wallet');
-                } else {
-                    console.error(err);
-                    setProofStatus('Error getting proof');
-                }
+                const message = err instanceof Error ? err.message : String(err);
+                setProofStatus(`Could not get proof: ${message}`);
+                setMessage('Failed to get proof from wallet');
                 setIsLoading(false);
                 return;
             }
@@ -157,25 +226,23 @@ export default function AllowListDApp(props: WalletConnectionProps) {
             setProofStatus('Verifying proof...');
             const resp = await fetch(`${VERIFIER_URL}/v0/verify`, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: proof.toString(),
             });
 
             if (resp.ok) {
                 setProofStatus('✅ Proof verified successfully!');
-                setMessage('EU nationality verified. Starting token distribution...');
+                setMessage(`${effectiveProof.description} verified. Starting token distribution...`);
                 await startTokenDistribution();
             } else {
                 const body = await resp.json();
                 setProofStatus(`❌ Proof verification failed`);
-                setMessage(`Failed to verify EU nationality: ${JSON.stringify(body)}`);
+                setMessage(`Failed to verify ${effectiveProof.description}: ${JSON.stringify(body)}`);
             }
         } catch (error: any) {
             console.error('Error requesting proof:', error);
             setProofStatus(`Error: ${error.message}`);
-            setMessage('Failed to request nationality proof');
+            setMessage(`Failed to request ${effectiveProof.description} proof`);
         } finally {
             setIsLoading(false);
         }
@@ -186,10 +253,8 @@ export default function AllowListDApp(props: WalletConnectionProps) {
             await connection.disconnect();
             setConnection(undefined);
             setIntentedConnectorType(null);
-            setTokenBalance('');
-            setIsOnAllowList(null);
+            setTokenBalances({});
             setMessage('Disconnected from wallet');
-            // Clear any other state as needed
             setProofStatus('');
             setTransactionHash('');
             setCurrentProof(null);
@@ -197,7 +262,6 @@ export default function AllowListDApp(props: WalletConnectionProps) {
     };
 
     useEffect(() => {
-        // Auto-connect only when the active connector matches what user clicked
         if (
             props.activeConnector &&
             !connection &&
@@ -208,7 +272,7 @@ export default function AllowListDApp(props: WalletConnectionProps) {
         ) {
             console.log('About to connect with connector:', props.activeConnector);
             connect();
-            setIntentedConnectorType(null); // Reset after connecting
+            setIntentedConnectorType(null);
         }
     }, [props.activeConnector, props.activeConnectorType, connection, isConnecting, connect, intentedConnectorType]);
 
@@ -224,13 +288,8 @@ export default function AllowListDApp(props: WalletConnectionProps) {
         try {
             const response = await fetch(`${BACKEND_URL}/token-distribution/distribute`, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    userAccount: account,
-                    tokenId: TOKEN_ID
-                }),
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ userAccount: account, tokenId: selectedTokenId }),
             });
 
             if (!response.ok) {
@@ -238,10 +297,7 @@ export default function AllowListDApp(props: WalletConnectionProps) {
             }
 
             const processStatus = await response.json();
-            const processId = processStatus.processId;
-
-            setMessage(`Process started: ${processId}`);
-            await pollProcessStatus(processId);
+            await pollProcessStatus(processStatus.processId);
 
         } catch (error: any) {
             console.error('Error in token distribution:', error);
@@ -252,53 +308,66 @@ export default function AllowListDApp(props: WalletConnectionProps) {
         }
     };
 
-    const pollProcessStatus = async (processId: string) => {
-        const maxAttempts = 90;
-        let attempts = 0;
+    const pollProcessStatus = (processId: string): Promise<void> => {
+        return new Promise((resolve) => {
+            const maxAttempts = 90;
+            let attempts = 0;
 
-        const poll = async () => {
-            try {
-                const response = await fetch(`${BACKEND_URL}/token-distribution/status/${processId}`);
-                if (!response.ok) {
-                    throw new Error('Failed to get process status');
-                }
+            const poll = async () => {
+                try {
+                    const response = await fetch(`${BACKEND_URL}/token-distribution/status/${processId}`);
+                    if (!response.ok) throw new Error('Failed to get process status');
 
-                const status = await response.json();
-                updateProcessStatus(status);
+                    const status = await response.json();
+                    updateProcessStatus(status);
 
-                if (status.status === 'completed') {
-                    setProofStatus('✅ Successfully added to allow list and received tokens!');
-                    setMessage('🎉 Process completed successfully!\n✅ Added to allow list\n✅ Tokens minted\n✅ Tokens transferred to your account\n\nAll operations completed in a single transaction!');
+                    if (status.status === 'completed') {
+                        const isAllowListOnly = (selectedToken?.amount ?? 1) === 0;
+                        setProofStatus(isAllowListOnly ? '✅ Added to allow list successfully!' : '✅ Tokens received successfully!');
+                        const allowListLine = selectedToken?.hasAllowList ? '✅ Added to allow list\n' : '';
+                        const mintTransferLines = isAllowListOnly ? '' : '✅ Tokens minted\n✅ Tokens transferred to your account\n';
+                        setMessage(`🎉 Process completed successfully!\n${allowListLine}${mintTransferLines}\nAll operations completed in a single transaction!`);
 
-                    if (status.result) {
-                        const txHash = status.result.transactionHash || 'Transaction completed';
-                        setTransactionHash(txHash);
+                        if (status.result?.transactionHash) {
+                            setTransactionHash(status.result.transactionHash);
+                        }
+
+                        // Optimistically mark balance as non-zero so the button disables immediately,
+                        // preventing a second claim in the same visit before the real fetch returns.
+                        setTokenBalances(prev => ({
+                            ...prev,
+                            [selectedTokenId]: String(selectedToken?.amount ?? 1),
+                        }));
+
+                        // Refresh real balances after finalization settles on-chain
+                        if (account) {
+                            setTimeout(() => fetchAllBalances(account, configuredTokens), 2000);
+                        }
+                        resolve();
+                        return;
+                    } else if (status.status === 'failed') {
+                        setProofStatus('❌ Process failed');
+                        setMessage(`Process failed: ${status.error}`);
+                        resolve();
+                        return;
+                    } else if (attempts >= maxAttempts) {
+                        setProofStatus('❌ Process timeout');
+                        setMessage('Process timed out - please check status manually');
+                        resolve();
+                        return;
                     }
 
-                    setIsOnAllowList(true);
-                    if (account) {
-                        setTimeout(() => fetchTokenBalance(account), 2000);
-                    }
-                    return;
-                } else if (status.status === 'failed') {
-                    setProofStatus('❌ Process failed');
-                    setMessage(`Process failed: ${status.error}`);
-                    return;
-                } else if (attempts >= maxAttempts) {
-                    setProofStatus('❌ Process timeout');
-                    setMessage('Process timed out - please check status manually');
-                    return;
+                    attempts++;
+                    setTimeout(poll, 5000);
+                } catch (error: any) {
+                    console.error('Error polling status:', error);
+                    setMessage(`Error checking status: ${error.message}`);
+                    resolve();
                 }
+            };
 
-                attempts++;
-                setTimeout(poll, 5000);
-            } catch (error: any) {
-                console.error('Error polling status:', error);
-                setMessage(`Error checking status: ${error.message}`);
-            }
-        };
-
-        poll();
+            poll();
+        });
     };
 
     const updateProcessStatus = (status: any) => {
@@ -324,16 +393,27 @@ export default function AllowListDApp(props: WalletConnectionProps) {
         setMessage(`Blockchain Transaction Status:\n${stepDetails}\n\nNote: All operations execute in a single atomic transaction using Token.sendOperations()!`);
     };
 
+    const selectedEligibility = selectedToken ? getTokenEligibility(selectedToken) : null;
+    const effectiveProof: ProofConfig | null = selectedToken?.hasAllowList
+        ? (selectedToken.proof ?? DEFAULT_EU_PROOF)
+        : null;
+
     const getButtonState = () => {
+        const isAllowListOnly = (selectedToken?.amount ?? 1) === 0;
+        const action = isAllowListOnly ? 'Join Allow List' : `Get ${selectedTokenId}`;
+        const claimText = effectiveProof
+            ? `Verify ${effectiveProof.description} & ${action}`
+            : action;
+
         if (!connection || isLoading) {
-            return { disabled: true, text: isLoading ? 'Processing...' : `Verify EU Nationality & Get ${TOKEN_ID}` };
+            return { disabled: true, text: isLoading ? 'Processing...' : claimText };
         }
 
-        if (isOnAllowList === true) {
-            return { disabled: true, text: `Already Received ${TOKEN_ID} ✅` };
+        if (selectedEligibility === false) {
+            return { disabled: true, text: isAllowListOnly ? `Already Added to Allow List ✅` : `Already Received ${selectedTokenId} ✅` };
         }
 
-        return { disabled: false, text: `Verify EU Nationality & Get ${TOKEN_ID}` };
+        return { disabled: false, text: claimText };
     };
 
     const buttonState = getButtonState();
@@ -343,6 +423,24 @@ export default function AllowListDApp(props: WalletConnectionProps) {
         wordBreak: 'break-word' as const,
         fontFamily: 'monospace',
         fontSize: '0.9rem'
+    };
+
+    const EligibilityBadge = ({ token }: { token: TokenConfig }) => {
+        const eligibility = getTokenEligibility(token);
+        const badgeStyle = { fontSize: '0.7rem', minWidth: '5.5rem', textAlign: 'center' as const };
+        if (isLoading && token.id === selectedTokenId) {
+            return <span className="badge rounded-pill text-bg-warning" style={badgeStyle}>Pending</span>;
+        }
+        if (balancesLoading && eligibility === null) {
+            return <span className="spinner-border spinner-border-sm text-muted" style={{ width: '0.8rem', height: '0.8rem', borderWidth: '0.15em' }} />;
+        }
+        if (eligibility === true) {
+            return <span className="badge rounded-pill text-bg-success" style={badgeStyle}>Unclaimed</span>;
+        }
+        if (eligibility === false) {
+            return <span className="badge rounded-pill text-bg-secondary" style={badgeStyle}>Received</span>;
+        }
+        return null;
     };
 
     return (
@@ -356,7 +454,7 @@ export default function AllowListDApp(props: WalletConnectionProps) {
                             height="30"
                             className="me-3"
                         />
-                        <span className="fw-light">Token Distribution dApp</span>
+                        <span className="fw-light fs-4">Token Distribution dApp</span>
                     </a>
                 </div>
             </nav>
@@ -373,7 +471,11 @@ export default function AllowListDApp(props: WalletConnectionProps) {
                                 <div className="d-grid gap-3">
                                     <button
                                         className="btn btn-outline-dark py-3"
-                                        onClick={() => {
+                                        onClick={async () => {
+                                            // requestAccounts prompts the wallet to show all accounts for selection.
+                                            // connect() (fired by useEffect after setActiveConnectorType) then resolves
+                                            // silently since permission is already established.
+                                            await window.concordium?.requestAccounts().catch(() => {});
                                             setIntentedConnectorType(BROWSER_WALLET);
                                             props.setActiveConnectorType(BROWSER_WALLET);
                                         }}
@@ -401,9 +503,10 @@ export default function AllowListDApp(props: WalletConnectionProps) {
                                         )}
                                     </button>
                                 </div>
+
                                 {connection && account && (
                                     <div className="mt-4">
-                                        <div className="alert alert-success border-0">
+                                        <div className="alert alert-success border-0 mb-3">
                                             <div className="d-flex align-items-center">
                                                 <i className="bi bi-check-circle-fill me-2"></i>
                                                 <div className="w-100">
@@ -417,88 +520,82 @@ export default function AllowListDApp(props: WalletConnectionProps) {
                                             </div>
                                         </div>
 
-                                        {/* Allow List Status Display */}
-                                        <div className="mt-3">
-                                            <div className="card border-0 bg-light">
-                                                <div className="card-body p-3">
-                                                    <h6 className="card-title fw-light mb-2">
-                                                        <i className="bi bi-shield-check me-2"></i>Allow List Status
+                                        {/* Token list with per-token eligibility and balance */}
+                                        <div className="card border-0 bg-light mb-3">
+                                            <div className="card-body p-3">
+                                                <div className="d-flex align-items-center justify-content-between mb-2">
+                                                    <h6 className="card-title fw-light mb-0">
+                                                        <i className="bi bi-coin me-2"></i>Tokens
                                                     </h6>
-                                                    <div className="d-flex align-items-center justify-content-between">
-                                                        <div>
-                                                            {allowListChecking ? (
-                                                                <span className="text-muted">
-                                                                    <span className="spinner-border spinner-border-sm me-2" role="status"></span>
-                                                                    Checking...
-                                                                </span>
-                                                            ) : isOnAllowList === true ? (
-                                                                <span className="fw-bold text-success">
-                                                                    <i className="bi bi-check-circle-fill me-1"></i>
-                                                                    On Allow List
-                                                                </span>
-                                                            ) : isOnAllowList === false ? (
-                                                                <span className="fw-bold text-warning">
-                                                                    <i className="bi bi-dash-circle-fill me-1"></i>
-                                                                    Not on Allow List
-                                                                </span>
-                                                            ) : (
-                                                                <span className="text-muted">
-                                                                    <i className="bi bi-question-circle me-1"></i>
-                                                                    Status Unknown
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                        <button
-                                                            className="btn btn-sm btn-outline-secondary"
-                                                            onClick={() => account && checkAllowListStatus(account)}
-                                                            disabled={allowListChecking || !account}
-                                                        >
-                                                            <i className="bi bi-arrow-clockwise"></i>
-                                                        </button>
-                                                    </div>
+                                                    <button
+                                                        className="btn btn-sm btn-outline-secondary"
+                                                        onClick={() => fetchAllBalances(account, configuredTokens)}
+                                                        disabled={balancesLoading}
+                                                        title="Refresh balances"
+                                                    >
+                                                        <i className="bi bi-arrow-clockwise"></i>
+                                                    </button>
+                                                </div>
+
+                                                <div className="d-flex flex-column gap-1">
+                                                    {configuredTokens.map(token => {
+                                                        const eligibility = getTokenEligibility(token);
+                                                        const isIneligible = eligibility === false;
+                                                        const isSelected = selectedTokenId === token.id;
+
+                                                        return (
+                                                            <div
+                                                                key={token.id}
+                                                                className={`d-flex align-items-center justify-content-between rounded px-2 py-2 ${isSelected ? 'bg-white shadow-sm border' : ''
+                                                                    }`}
+                                                                style={{
+                                                                    opacity: isIneligible ? 0.55 : 1,
+                                                                    cursor: isMultiToken && !isIneligible && !isLoading ? 'pointer' : 'default',
+                                                                }}
+                                                                onClick={() => {
+                                                                    if (isMultiToken && !isIneligible && !isLoading) setSelectedTokenId(token.id);
+                                                                }}
+                                                            >
+                                                                <div className="d-flex align-items-center gap-2">
+                                                                    {isMultiToken && (
+                                                                        <input
+                                                                            type="radio"
+                                                                            className="form-check-input mt-0 flex-shrink-0"
+                                                                            name="tokenSelector"
+                                                                            checked={isSelected}
+                                                                            disabled={isIneligible || isLoading}
+                                                                            onChange={() => setSelectedTokenId(token.id)}
+                                                                        />
+                                                                    )}
+                                                                    <div>
+                                                                        <span className="fw-medium">{token.id}</span>
+                                                                        <span className="text-muted ms-1" style={{ fontSize: '0.78rem' }}>
+                                                                            ({token.amount})
+                                                                        </span>
+                                                                    </div>
+                                                                </div>
+                                                                <div className="d-flex align-items-center gap-2">
+                                                                    <span className="text-muted" style={{ fontSize: '0.82rem' }}>
+                                                                        {balancesLoading
+                                                                            ? '…'
+                                                                            : `${tokenBalances[token.id] ?? '0'}`}
+                                                                    </span>
+                                                                    <EligibilityBadge token={token} />
+                                                                </div>
+                                                            </div>
+                                                        );
+                                                    })}
                                                 </div>
                                             </div>
                                         </div>
 
-                                        <div className="d-grid mt-2">
+                                        <div className="d-grid">
                                             <button
                                                 className="btn btn-outline-danger btn-sm"
                                                 onClick={handleDisconnect}
                                             >
                                                 <i className="bi bi-power me-2"></i>Disconnect Wallet
                                             </button>
-                                        </div>
-
-                                        {/* Token Balance Display */}
-                                        <div className="mt-3">
-                                            <div className="card border-0 bg-light">
-                                                <div className="card-body p-3">
-                                                    <h6 className="card-title fw-light mb-2">
-                                                        <i className="bi bi-coin me-2"></i>{TOKEN_ID} Balance
-                                                    </h6>
-                                                    <div className="d-flex align-items-center justify-content-between">
-                                                        <div>
-                                                            {balanceLoading ? (
-                                                                <span className="text-muted">
-                                                                    <span className="spinner-border spinner-border-sm me-2" role="status"></span>
-                                                                    Loading...
-                                                                </span>
-                                                            ) : (
-                                                                <span className="fw-bold text-primary" style={{ fontSize: '1.1rem' }}>
-                                                                    {tokenBalance || '0'} {TOKEN_ID}
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                        <button
-                                                            className="btn btn-sm btn-outline-secondary"
-                                                            onClick={() => account && fetchTokenBalance(account)}
-                                                            disabled={balanceLoading || !account}
-                                                        >
-                                                            <i className="bi bi-arrow-clockwise"></i>
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </div>
                                         </div>
                                     </div>
                                 )}
@@ -510,64 +607,117 @@ export default function AllowListDApp(props: WalletConnectionProps) {
                         <div className="card border-0 shadow-sm h-100">
                             <div className="card-body p-4">
                                 <h5 className="card-title fw-light mb-4">
-                                    <i className="bi bi-globe-europe-africa me-2"></i>EU Nationality Verification
+                                    <i className="bi bi-coin me-2"></i>
+                                    Get Tokens
                                 </h5>
-                                <p className="text-muted small mb-4">
-                                    Verify your EU nationality to be added to the token's allow list and receive tokens.
-                                </p>
-
-                                {/* Process flow description - Single Transaction */}
-                                <div className="alert alert-info border-0 mb-3">
-                                    <div className="small">
-                                        <strong>Proof of concept, how it works:</strong>
-                                        <ol className="mb-0 mt-1 ps-3">
-                                            <li>Verify you're eligible for the {TOKEN_ID} tokens</li>
-                                            <li>Add to allow list</li>
-                                            <li>Mint 100 new {TOKEN_ID} tokens</li>
-                                            <li>Transfer tokens directly to your wallet</li>
-                                        </ol>
-                                        <p className="mb-0 mt-2">
-                                            <em>✨ All operations execute atomically in one transaction - instant and secure!</em>
+                                {!connection ? (
+                                    <div className="d-flex flex-column gap-2">
+                                        {configuredTokens.length === 0 ? (
+                                            <p className="text-muted small">Loading available tokens...</p>
+                                        ) : configuredTokens.map(token => {
+                                            const tokenProof = token.hasAllowList ? (token.proof ?? DEFAULT_EU_PROOF) : null;
+                                            return (
+                                                <div key={token.id} className="card border-0 bg-light">
+                                                    <div className="card-body p-3">
+                                                        <div className="d-flex align-items-center gap-3">
+                                                            <div
+                                                                className="rounded-circle bg-dark d-flex align-items-center justify-content-center flex-shrink-0 overflow-hidden"
+                                                                style={{ width: '2.5rem', height: '2.5rem' }}
+                                                            >
+                                                                {token.iconUrl ? (
+                                                                    <img src={token.iconUrl} alt={token.id} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                                                                ) : (
+                                                                    <i className="bi bi-coin text-white fs-6"></i>
+                                                                )}
+                                                            </div>
+                                                            <div className="flex-grow-1">
+                                                                <div className="fw-semibold">{token.id}</div>
+                                                                {token.description && (
+                                                                    <div className="small text-muted">{token.description}</div>
+                                                                )}
+                                                                {token.amount === 0 ? (
+                                                                    <div className="small text-secondary fst-italic">Allow list addition only</div>
+                                                                ) : (
+                                                                    <div className="small">Claim {token.amount} PLTs</div>
+                                                                )}
+                                                                {tokenProof ? (
+                                                                    <div className="small mt-1 text-primary">
+                                                                        <i className="bi bi-shield-lock me-1"></i>
+                                                                        Requires {tokenProof.description} verification
+                                                                    </div>
+                                                                ) : (
+                                                                    <div className="small mt-1 text-success">
+                                                                        <i className="bi bi-check-circle me-1"></i>
+                                                                        No verification required
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                ) : (
+                                    <>
+                                        <p className="text-muted small mb-4">
+                                            {effectiveProof
+                                                ? `This token requires ${effectiveProof.description} verification.`
+                                                : 'No verification required — claim this token directly.'}
                                         </p>
-                                    </div>
-                                </div>
 
-                                <div className="d-grid">
-                                    <button
-                                        className={`btn py-3 ${buttonState.disabled ? 'btn-secondary' : 'btn-dark'}`}
-                                        onClick={requestCitizenshipProof}
-                                        disabled={buttonState.disabled}
-                                    >
-                                        {isLoading ? (
-                                            <>
-                                                <span className="spinner-border spinner-border-sm me-2" role="status"></span>
-                                                Processing...
-                                            </>
-                                        ) : (
-                                            buttonState.text
-                                        )}
-                                    </button>
-                                </div>
-
-                                {proofStatus && (
-                                    <div className="mt-4">
-                                        <div className={`alert border-0 ${proofStatus.includes('✅') ? 'alert-success' :
-                                            proofStatus.includes('❌') ? 'alert-danger' :
-                                                'alert-info'
-                                            }`}>
-                                            {proofStatus}
+                                        {/* Process flow description */}
+                                        <div className="alert alert-info border-0 mb-3">
+                                            <div className="small">
+                                                <strong>Proof of concept, how it works:</strong>
+                                                <ol className="mb-0 mt-1 ps-3">
+                                                    <li>Verify you're eligible for {selectedTokenId}</li>
+                                                    {selectedToken?.hasAllowList && <li>Add to allow list</li>}
+                                                    {(selectedToken?.amount ?? 1) > 0 && <li>Mint {selectedToken?.amount} new {selectedTokenId} PLTs</li>}
+                                                    {(selectedToken?.amount ?? 1) > 0 && <li>Transfer PLTs directly to your wallet</li>}
+                                                </ol>
+                                                <p className="mb-0 mt-2">
+                                                    <em>✨ All operations execute atomically in one transaction - instant and secure!</em>
+                                                </p>
+                                            </div>
                                         </div>
-                                    </div>
-                                )}
 
-                                {currentProof && (
-                                    <button
-                                        className="btn btn-sm btn-link text-muted mt-2 p-0"
-                                        onClick={() => setShowProofDetails(!showProofDetails)}
-                                    >
-                                        <i className="bi bi-info-circle me-1"></i>
-                                        {showProofDetails ? 'Hide' : 'View'} proof details
-                                    </button>
+                                        <div className="d-grid">
+                                            <button
+                                                className={`btn py-3 ${buttonState.disabled ? 'btn-secondary' : 'btn-dark'}`}
+                                                onClick={requestCitizenshipProof}
+                                                disabled={buttonState.disabled}
+                                            >
+                                                {isLoading ? (
+                                                    <>
+                                                        <span className="spinner-border spinner-border-sm me-2" role="status"></span>
+                                                        Processing...
+                                                    </>
+                                                ) : (
+                                                    buttonState.text
+                                                )}
+                                            </button>
+                                        </div>
+
+                                        {proofStatus && (
+                                            <div className="mt-4">
+                                                <div className={`alert border-0 ${proofStatus.includes('✅') ? 'alert-success' :
+                                                    proofStatus.includes('❌') ? 'alert-danger' : 'alert-info'}`}>
+                                                    {proofStatus}
+                                                </div>
+                                            </div>
+                                        )}
+
+                                        {currentProof && (
+                                            <button
+                                                className="btn btn-sm btn-link text-muted mt-2 p-0"
+                                                onClick={() => setShowProofDetails(!showProofDetails)}
+                                            >
+                                                <i className="bi bi-info-circle me-1"></i>
+                                                {showProofDetails ? 'Hide' : 'View'} proof details
+                                            </button>
+                                        )}
+                                    </>
                                 )}
                             </div>
                         </div>
@@ -579,11 +729,9 @@ export default function AllowListDApp(props: WalletConnectionProps) {
                         <div className="col-12">
                             {message && (
                                 <div className={`alert border-0 shadow-sm ${message.includes('Failed') || message.includes('Error') ?
-                                        'alert-danger' : 'alert-info'
-                                    }`}>
+                                    'alert-danger' : 'alert-info'}`}>
                                     <i className={`bi me-2 ${message.includes('Failed') || message.includes('Error') ?
-                                            'bi-exclamation-triangle' : 'bi-info-circle'
-                                        }`}></i>
+                                        'bi-exclamation-triangle' : 'bi-info-circle'}`}></i>
                                     <span style={messageStyle}>{message}</span>
                                 </div>
                             )}
@@ -599,7 +747,11 @@ export default function AllowListDApp(props: WalletConnectionProps) {
                                             <p className="font-monospace small text-break">{transactionHash}</p>
                                             <p className="small text-muted mt-2">
                                                 <i className="bi bi-info-circle me-1"></i>
-                                                This single transaction performed all operations: allow list addition, token minting, and transfer!
+                                                {selectedToken?.hasAllowList && (selectedToken?.amount ?? 1) === 0
+                                                    ? 'This single transaction performed all operations: allow list addition only!'
+                                                    : selectedToken?.hasAllowList
+                                                        ? 'This single transaction performed all operations: allow list addition, token minting, and transfer!'
+                                                        : 'This single transaction performed all operations: token minting and transfer!'}
                                             </p>
                                         </div>
                                     </div>

--- a/allowListManagerFaucet/frontend/vite.config.ts
+++ b/allowListManagerFaucet/frontend/vite.config.ts
@@ -1,20 +1,32 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@concordium/rust-bindings': '@concordium/rust-bindings/bundler',
-    }
-  },
-  plugins: [
-    react(),
-    wasm(),
-    topLevelAwait(),
-  ],
-  define: {
-    global: 'globalThis',
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    resolve: {
+      alias: {
+        '@concordium/rust-bindings': '@concordium/rust-bindings/bundler',
+      }
+    },
+    plugins: [
+      react(),
+      wasm(),
+      topLevelAwait(),
+      {
+        name: 'inject-runtime-config',
+        transformIndexHtml(html) {
+          return html
+            .replace('__BACKEND_URL__', env.BACKEND_URL || 'http://localhost:3001')
+            .replace('__VERIFIER_URL__', env.VERIFIER_URL || 'http://localhost:7017');
+        },
+      },
+    ],
+    define: {
+      global: 'globalThis',
+    },
+  };
 });


### PR DESCRIPTION
## Purpose

We can now manage multiple tokens with configurable proofs on tokens that have an allow list. Each token has it's own configuration for both the amount to airdrop, whether to add the user to the allow list, and the kind of proof required when doing so. (supports set inclusion/exclusion four country fields, and range for dob)

## Changes

Frontend and backend changes to support multiple tokens, with backwards compatibility with the single token version

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
